### PR TITLE
chore: change Renovate to commit semantically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["config:base"],
+	"extends": ["config:base", ":semanticCommits"],
 	"schedule": ["after 8pm every weekday", "before 7pm on Sunday"],
 	"packageRules": [
 		{


### PR DESCRIPTION
Change Renovate to adhere to [semantic commits](https://docs.renovatebot.com/semantic-commits/).