### PR TITLE
chore: set license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kordis",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "ng": "nx",
     "postinstall": "node ./decorate-angular-cli.js",


### PR DESCRIPTION
We forgot to set our license in the package.json. We should be consistent, even if our package stays private (not published on npm...).