### PR TITLE
chore: fix renovate nrwl package exclusion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,9 @@
 				"jest-preset-angular",
 				"ts-jest",
 				"typescript",
-				"^@nrlw/",
+				"^@nrwl/",
 				"^@nestjs/",
+				"nx",
 				"zone.js"
 			],
 			"enabled": false


### PR DESCRIPTION
wrong package name, added nx to completly disable prs related to nx workspace updates