### PR TITLE
docs: add architecture decision log

### DIFF
--- a/docs/architecture-decisions/adr000-template.md
+++ b/docs/architecture-decisions/adr000-template.md
@@ -1,0 +1,21 @@
+<!-- These documents have names that are short noun phrases. For example, "ADR001: Deployment on Ruby on Rails 3.0.10" or "ADR009: LDAP for Multitenant Integration" -->
+
+# Title
+
+## Status
+
+What is the status, such as accepted, deprecated, superseded? (Should be _accepted_ when merging a PR; Should include a reference to the ADR superseding it; Should contain a short explanation why it is deprecated)
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+<!-- This template is taken from a blog post by Michael Nygard http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions -->

--- a/docs/architecture-decisions/adr001-add-adr-log.md
+++ b/docs/architecture-decisions/adr001-add-adr-log.md
@@ -1,0 +1,17 @@
+# ADR001: Architecture Decision Record (ADR) log
+
+## Status
+
+accepted
+
+## Context
+
+There is a need to store big decisions made in a log as a reference point for the team, help with onboarding new members and give context to others interested in the project.
+
+## Decision
+
+A decision was made to store ADRs in a log in the project repository.
+
+## Consequences
+
+We are aware of past decisions and can reconstruct how we arrived at them.


### PR DESCRIPTION
This PR adds an architecture decision log as discussed in #49. Closes #49.