### PR TITLE
chore: add eslint plugin for jest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,8 +44,12 @@
 			"env": {
 				"jest": true
 			},
+			"plugins": ["jest"],
+			"extends": ["plugin:jest/recommended"],
 			"rules": {
-				"no-console": "off"
+				"no-console": "off",
+				"@typescript-eslint/no-empty-function": "off",
+				"@typescript-eslint/explicit-function-return-type": "off"
 			}
 		}
 	]

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint": "8.36.0",
         "eslint-config-prettier": "8.8.0",
         "eslint-plugin-cypress": "^2.10.3",
+        "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-rxjs": "^5.0.2",
         "husky": "^8.0.0",
         "jest": "29.4.3",
@@ -12415,6 +12416,30 @@
       },
       "peerDependencies": {
         "eslint": ">= 3.2.1"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-rxjs": {
@@ -36753,6 +36778,15 @@
       "dev": true,
       "requires": {
         "globals": "^11.12.0"
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-rxjs": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint": "8.36.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-cypress": "^2.10.3",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-rxjs": "^5.0.2",
     "husky": "^8.0.0",
     "jest": "29.4.3",


### PR DESCRIPTION
Adds recommended eslint rules for jests tests. 
Deactivates two typescript eslint rules that get annoying to manually ignore and are a common thing to use in tests.