### PR TITLE
feat(api): target es2021

### DIFF
--- a/libs/api/shared/tsconfig.lib.json
+++ b/libs/api/shared/tsconfig.lib.json
@@ -1,1 +1,11 @@
-undefined
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"],
+		"target": "es2021"
+	},
+	"include": ["src/**/*.ts", "../../../reset.d.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/api/test-helpers/tsconfig.lib.json
+++ b/libs/api/test-helpers/tsconfig.lib.json
@@ -1,1 +1,10 @@
-undefined
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -56,7 +56,8 @@
 			"inlineTemplate": true
 		},
 		"@nx/nest:library": {
-			"strict": true
+			"strict": true,
+			"target": "es2021"
 		}
 	}
 }


### PR DESCRIPTION
Update target to `es2021` for API instead of es6 to enable the use of new features.
NestJS itself targets `es2021`.