### PR TITLE
ci: fix preview build being tagged with head's sha

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/build-and-deploy-api
         with:
           slot: "pr${{ github.event.issue.number }}"
-          releaseVersion: ${{ github.sha }}
+          releaseVersion: ${{ github.event.pull_request.head.sha }}
           sentryKey: ${{ secrets.API_SENTRY_KEY }}
           sentryAuthToken: ${{ secrets.SENTRY_AUTH_TOKEN }}
           containerRegistryUrl: ghcr.io
@@ -185,7 +185,7 @@ jobs:
         uses: ./.github/actions/build-and-deploy-api
         with:
           slot: "pr${{ github.event.pull_request.number }}"
-          releaseVersion: ${{ github.sha }}
+          releaseVersion: ${{ github.event.pull_request.head.sha }}
           sentryKey: ${{ secrets.API_SENTRY_KEY }}
           sentryAuthToken: ${{ secrets.SENTRY_AUTH_TOKEN }}
           containerRegistryUrl: ghcr.io


### PR DESCRIPTION
# Description

Currently, preview builds in PRs are tagged with the commit sha of the merge commit instead of the head's commit (see [this SO discussion](https://stackoverflow.com/questions/63594658/git-refs-merge-vs-head-in-pull-request) for more info. Change to tag with the head's sha.

Fixes #329

# Checklist:

- [ ] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [ ] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [ ] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
