### PR TITLE
feat(spa): add network and service health checks via Instatus

### DIFF
--- a/apps/spa/src/app/app.module.ts
+++ b/apps/spa/src/app/app.module.ts
@@ -8,6 +8,10 @@ import {
 	NoopObservabilityModule,
 	SentryObservabilityModule,
 } from '@kordis/spa/observability';
+import {
+	InstatusServiceHealthModule,
+	NoopServiceHealthModule,
+} from '@kordis/spa/service-health';
 
 import { environment } from '../environments/environment';
 import { AppComponent } from './component/app.component';
@@ -34,6 +38,9 @@ import routes from './routes';
 					environment.releaseVersion,
 			  )
 			: NoopObservabilityModule.forRoot(),
+		environment.instatusUrl
+			? InstatusServiceHealthModule.forRoot(environment.instatusUrl)
+			: NoopServiceHealthModule,
 	],
 	providers: [],
 	bootstrap: [AppComponent],

--- a/apps/spa/src/environments/environment.model.ts
+++ b/apps/spa/src/environments/environment.model.ts
@@ -7,4 +7,5 @@ export type Environment = {
 	releaseVersion: string;
 	oauth?: { discoveryDocumentUrl: string; config: AuthConfig };
 	sentryKey?: string;
+	instatusUrl?: string;
 };

--- a/apps/spa/src/environments/environment.ts
+++ b/apps/spa/src/environments/environment.ts
@@ -5,4 +5,5 @@ export const environment: Environment = {
 	environmentName: 'Dev Local',
 	releaseVersion: '0.0.0-development',
 	apiUrl: 'https://localhost:3000',
+	instatusUrl: 'https://kordis.instatus.com',
 };

--- a/libs/spa/service-health/.eslintrc.json
+++ b/libs/spa/service-health/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+	"extends": ["../../../.eslintrc.json", "../../../.eslintrc.angular.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts"],
+			"rules": {
+				"@angular-eslint/directive-selector": [
+					"error",
+					{
+						"type": "attribute",
+						"prefix": "krd",
+						"style": "camelCase"
+					}
+				],
+				"@angular-eslint/component-selector": [
+					"error",
+					{
+						"type": "element",
+						"prefix": "krd",
+						"style": "kebab-case"
+					}
+				]
+			},
+			"extends": [
+				"plugin:@nx/angular",
+				"plugin:@angular-eslint/template/process-inline-templates"
+			]
+		},
+		{
+			"files": ["*.html"],
+			"extends": ["plugin:@nx/angular-template"],
+			"rules": {}
+		}
+	]
+}

--- a/libs/spa/service-health/README.md
+++ b/libs/spa/service-health/README.md
@@ -1,0 +1,14 @@
+# Service Health
+
+This library contains services and components for displaying the health of the
+services around Kordis and Kordis itself, as well as the network status of the
+SPA. Currently, we aggregate the health of the services via
+[Instatus](https://kordis.instatus.com/). There, we have automatic checks for
+services and the opportunity to schedule maintenances. There is no communication
+with the Kordis API to allow notifications on interruptions with any Kordis
+Services besides their health status. Currently, the status will be fetched
+every 30 seconds.
+
+## Running unit tests
+
+Run `nx test spa-service-health` to execute the unit tests.

--- a/libs/spa/service-health/jest.config.ts
+++ b/libs/spa/service-health/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+	displayName: 'spa-service-health',
+	preset: '../../../jest.preset.js',
+	setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+	coverageDirectory: '../../../coverage/libs/spa/service-health',
+	transform: {
+		'^.+\\.(ts|mjs|js|html)$': [
+			'jest-preset-angular',
+			{
+				tsconfig: '<rootDir>/tsconfig.spec.json',
+				stringifyContentPathRegex: '\\.(html|svg)$',
+			},
+		],
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+	snapshotSerializers: [
+		'jest-preset-angular/build/serializers/no-ng-attributes',
+		'jest-preset-angular/build/serializers/ng-snapshot',
+		'jest-preset-angular/build/serializers/html-comment',
+	],
+};

--- a/libs/spa/service-health/project.json
+++ b/libs/spa/service-health/project.json
@@ -1,0 +1,34 @@
+{
+	"name": "spa-service-health",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "libs/spa/service-health/src",
+	"prefix": "krd",
+	"tags": [],
+	"projectType": "library",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/spa/service-health/jest.config.ts",
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"libs/spa/service-health/**/*.ts",
+					"libs/spa/service-health/**/*.html"
+				]
+			}
+		}
+	}
+}

--- a/libs/spa/service-health/src/index.ts
+++ b/libs/spa/service-health/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/instatus-service-health.module';
+export * from './lib/noop-service-health.module';
+export * from './lib/service-health.service';
+export * from './lib/network-health-staus.service';

--- a/libs/spa/service-health/src/lib/instatus-service-health.module.ts
+++ b/libs/spa/service-health/src/lib/instatus-service-health.module.ts
@@ -1,0 +1,27 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+
+import { InstatusServiceHealthService } from './instatus-service-health.service';
+import { SERVICE_HEALTH_SERVICE } from './service-health.service';
+
+@NgModule({
+	imports: [CommonModule],
+})
+export class InstatusServiceHealthModule {
+	static forRoot(
+		instatusUrl: string,
+		checkIntervalMs = 30000,
+	): ModuleWithProviders<InstatusServiceHealthModule> {
+		return {
+			ngModule: InstatusServiceHealthModule,
+			providers: [
+				DatePipe,
+				{
+					provide: SERVICE_HEALTH_SERVICE,
+					useFactory: () =>
+						new InstatusServiceHealthService(instatusUrl, checkIntervalMs),
+				},
+			],
+		};
+	}
+}

--- a/libs/spa/service-health/src/lib/instatus-service-health.service.spec.ts
+++ b/libs/spa/service-health/src/lib/instatus-service-health.service.spec.ts
@@ -1,0 +1,132 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { InstatusServiceHealthService } from './instatus-service-health.service';
+import { DatePipe } from '@angular/common';
+import { lastValueFrom, take, toArray } from 'rxjs';
+
+Object.defineProperty(URL, 'createObjectURL', {
+	value: jest.fn(),
+});
+
+class MockWorker {
+	static mockInstanceSingleton: MockWorker | null;
+	onmessage!: (payload: { data: unknown }) => void;
+
+	constructor() {
+		MockWorker.mockInstanceSingleton = this;
+	}
+}
+
+Object.defineProperty(window, 'Worker', {
+	value: MockWorker,
+});
+
+const EXAMPLE_INSTATUS_RESPONSE = Object.freeze({
+	activeIncidents: [
+		{
+			id: 'someid1',
+			name: 'test',
+			status: 'INVESTIGATING',
+			impact: 'MAJOROUTAGE',
+			url: 'https://kordis.instatus.com/someid1',
+		},
+	],
+	activeMaintenances: [
+		{
+			id: 'someid3',
+			name: 'test',
+			start: '2023-11-05T15:36:34.932Z',
+			status: 'NOTSTARTEDYET',
+			duration: 60,
+			url: 'https://kordis.instatus.com/someid3',
+		},
+	],
+});
+
+describe('InstatusServiceHealthService', () => {
+	let spectator: SpectatorService<InstatusServiceHealthService>;
+	let service: InstatusServiceHealthService;
+
+	// Prepare the service factory
+	const createService = createServiceFactory({
+		service: InstatusServiceHealthService,
+		providers: [DatePipe],
+	});
+
+	beforeEach(() => {
+		spectator = createService({
+			providers: [
+				{ provide: 'instatusUrl', useValue: 'https://kordis.instatus.com' },
+				{ provide: 'checkIntervalMs', useValue: 60000 },
+			],
+		});
+		service = spectator.service;
+	});
+
+	afterEach(() => {
+		MockWorker.mockInstanceSingleton = null;
+	});
+
+	it('should emit correct service status reports', async () => {
+		MockWorker.mockInstanceSingleton?.onmessage({
+			data: EXAMPLE_INSTATUS_RESPONSE,
+		});
+
+		await expect(
+			lastValueFrom(service.serviceStatusChanged$.pipe(take(2), toArray())),
+		).resolves.toEqual([
+			{
+				message: 'test. Auswirkung: Großer Ausfall',
+				status: 'down',
+				url: 'https://kordis.instatus.com/someid1',
+			},
+			{
+				message: 'test - am 16:36 05.11. für 60 Minuten.',
+				status: 'maintenance_scheduled',
+				url: 'https://kordis.instatus.com/someid3',
+			},
+		]);
+	});
+
+	it('should emit changed status', async () => {
+		MockWorker.mockInstanceSingleton?.onmessage({
+			data: EXAMPLE_INSTATUS_RESPONSE,
+		});
+		MockWorker.mockInstanceSingleton?.onmessage({
+			data: {
+				activeIncidents: [
+					{
+						id: 'someid1',
+						name: 'test',
+						status: 'RESOLVED',
+						url: 'https://kordis.instatus.com/someid1',
+					},
+				],
+				activeMaintenances: [
+					{
+						id: 'someid3',
+						name: 'test',
+						start: '2023-11-05T15:36:34.932Z',
+						status: 'INPROGRESS',
+						duration: 60,
+						url: 'https://kordis.instatus.com/someid3',
+					},
+				],
+			},
+		});
+
+		await expect(
+			lastValueFrom(service.serviceStatusChanged$.pipe(take(2), toArray())),
+		).resolves.toEqual([
+			{
+				message: 'test',
+				status: 'up',
+				url: 'https://kordis.instatus.com/someid1',
+			},
+			{
+				message: 'test - bis 17:36 05.11.',
+				status: 'maintenance',
+				url: 'https://kordis.instatus.com/someid3',
+			},
+		]);
+	});
+});

--- a/libs/spa/service-health/src/lib/instatus-service-health.service.ts
+++ b/libs/spa/service-health/src/lib/instatus-service-health.service.ts
@@ -1,0 +1,204 @@
+import { DatePipe } from '@angular/common';
+import { Inject, inject, Injectable } from '@angular/core';
+import {
+	concatAll,
+	map,
+	Observable,
+	ReplaySubject,
+	scan,
+	shareReplay,
+} from 'rxjs';
+
+import { ServiceHealthService } from './service-health.service';
+import { ServiceStatusReport } from './service-status-report.model';
+
+const IMPACT_MAP: Readonly<Record<string, string>> = Object.freeze({
+	DEGRADEDPERFORMANCE: 'Leistungseinbußen',
+	PARTIALOUTAGE: 'Teilausfall',
+	OPERATIONAL: 'Funktionsfähig',
+	UNDERMAINTENANCE: 'Wartung',
+	MAJOROUTAGE: 'Großer Ausfall',
+});
+
+interface InstatusIncident {
+	name: string;
+	started: string;
+	status: string;
+	impact: string;
+	url: string;
+}
+
+interface InstatusMaintenance {
+	name: string;
+	start: string;
+	status: string;
+	duration: string;
+	url: string;
+}
+
+interface InstatusResponse {
+	activeIncidents?: InstatusIncident[];
+	activeMaintenances: InstatusMaintenance[];
+}
+
+@Injectable()
+export class InstatusServiceHealthService implements ServiceHealthService {
+	private readonly datePipe = inject(DatePipe);
+	private readonly instatusChangedSubject$ =
+		new ReplaySubject<InstatusResponse>(1);
+
+	serviceStatusChanged$: Observable<ServiceStatusReport> =
+		this.instatusChangedSubject$.pipe(
+			scan(
+				(acc, curr) => {
+					// we have interest in all active incidents that are not already in the accumulator or have a different status
+					acc.incidents =
+						curr.activeIncidents?.filter(
+							(report) =>
+								!acc.incidents.some(
+									(i) => i.name === report.name && i.status === report.status,
+								),
+						) ?? [];
+
+					acc.maintenances =
+						curr.activeMaintenances?.filter(
+							(report) =>
+								!acc.maintenances.some(
+									(i) => i.name === report.name && i.status === report.status,
+								),
+						) ?? [];
+
+					return acc;
+				},
+				{
+					incidents: [] as InstatusIncident[],
+					maintenances: [] as InstatusMaintenance[],
+				},
+			),
+			map((response) => [
+				...(response.incidents
+					? response.incidents.map((incident: InstatusIncident) =>
+							this.mapIncidentToReport(incident),
+					  )
+					: []),
+				...(response.maintenances
+					? response.maintenances.map((maintenance: InstatusMaintenance) =>
+							this.mapMaintenanceToReport(maintenance),
+					  )
+					: []),
+			]),
+			shareReplay({ bufferSize: 1, refCount: true }),
+			concatAll(),
+		);
+
+	constructor(
+		@Inject('instatusUrl') instatusUrl: string,
+		@Inject('checkIntervalMs') checkIntervalMs: number,
+	) {
+		this.startWorker(instatusUrl, checkIntervalMs);
+	}
+
+	private startWorker(instatusUrl: string, checkIntervalMs: number): void {
+		const blob = new Blob(
+			[
+				`
+          let latestState = "";
+					const checkForChanges = async () => {
+						const response = await fetch('${instatusUrl}/summary.json', {cache: "no-store"});
+            const currentState = await response.text();
+
+						if (currentState !== latestState) {
+							latestState = currentState;
+							self.postMessage(JSON.parse(currentState));
+						}
+					};
+					checkForChanges();
+					setInterval(checkForChanges, ${checkIntervalMs});
+      `,
+			],
+			{ type: 'application/javascript' },
+		);
+
+		const url = URL.createObjectURL(blob);
+
+		const instatusStateChangeWorker = new Worker(url);
+
+		instatusStateChangeWorker.onmessage = ({ data }) => {
+			this.instatusChangedSubject$.next(data);
+		};
+	}
+
+	private mapMaintenanceToReport(
+		maintenance: InstatusMaintenance,
+	): ServiceStatusReport {
+		switch (maintenance.status) {
+			case 'NOTSTARTEDYET':
+				return {
+					message: `${maintenance.name} - am ${this.dateStringToShortDateString(
+						maintenance.start,
+					)} für ${maintenance.duration} Minuten.`,
+					status: 'maintenance_scheduled',
+					url: maintenance.url,
+				};
+			case 'INPROGRESS': {
+				const maintenanceEnd = new Date(maintenance.start);
+				maintenanceEnd.setMinutes(
+					maintenanceEnd.getMinutes() + Number(maintenance.duration),
+				);
+
+				return {
+					message: `${
+						maintenance.name
+					} - bis ${this.dateStringToShortDateString(
+						maintenanceEnd.toISOString(),
+					)}`,
+					status: 'maintenance',
+					url: maintenance.url,
+				};
+			}
+
+			case 'COMPLETED':
+				return {
+					message: maintenance.name,
+					status: 'up',
+					url: maintenance.url,
+				};
+		}
+
+		return {
+			message: maintenance.name,
+			status: 'maintenance',
+			url: maintenance.url,
+		};
+	}
+
+	private mapIncidentToReport(incident: InstatusIncident): ServiceStatusReport {
+		switch (incident.status) {
+			case 'INVESTIGATING':
+			case 'IDENTIFIED':
+				return {
+					message:
+						`${incident.name}. Auswirkung: ` + IMPACT_MAP[incident.impact],
+					status: 'down',
+					url: incident.url,
+				};
+			case 'MONITORING':
+			case 'RESOLVED':
+				return {
+					message: incident.name,
+					status: 'up',
+					url: incident.url,
+				};
+		}
+
+		return {
+			message: incident.name,
+			status: 'down',
+			url: incident.url,
+		};
+	}
+
+	private dateStringToShortDateString(dateString: string): string | null {
+		return this.datePipe.transform(new Date(dateString), 'HH:mm dd.MM.');
+	}
+}

--- a/libs/spa/service-health/src/lib/network-health-staus.service.spec.ts
+++ b/libs/spa/service-health/src/lib/network-health-staus.service.spec.ts
@@ -1,0 +1,76 @@
+import { firstValueFrom, skip } from 'rxjs';
+import { NetworkHealthStatusService } from './network-health-staus.service';
+
+describe('NetworkHealthStatusService', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should emit true as initial status when the browser is online', async () => {
+		Object.defineProperty(navigator, 'onLine', {
+			value: true,
+		});
+
+		const status = await firstValueFrom(
+			new NetworkHealthStatusService().statusChanged$,
+		);
+		expect(status).toBe(true);
+	});
+
+	it('should emit false as initial status when the browser is offline', async () => {
+		Object.defineProperty(navigator, 'onLine', {
+			value: false,
+		});
+
+		const status = await firstValueFrom(
+			new NetworkHealthStatusService().statusChanged$,
+		);
+		expect(status).toBe(false);
+	});
+
+	it('should emit false when the window goes offline', async () => {
+		Object.defineProperty(navigator, 'onLine', {
+			value: true,
+		});
+
+		let eventValue: Promise<boolean>;
+		const offlineHandler: EventListener = await new Promise((resolve) => {
+			jest
+				.spyOn(window, 'addEventListener')
+				.mockImplementation((event, handler) => {
+					if (event === 'offline') {
+						resolve(handler as EventListener);
+					}
+				});
+			eventValue = firstValueFrom(
+				new NetworkHealthStatusService().statusChanged$.pipe(skip(1)),
+			);
+		});
+
+		offlineHandler(new Event('offline'));
+		await expect(eventValue!).resolves.toBe(false);
+	});
+
+	it('should emit true when the window goes online', async () => {
+		Object.defineProperty(navigator, 'onLine', {
+			value: false,
+		});
+
+		let statusChangeValuePromise: Promise<boolean>;
+		const onlineHandler: EventListener = await new Promise((resolve) => {
+			jest
+				.spyOn(window, 'addEventListener')
+				.mockImplementation((event, handler) => {
+					if (event === 'online') {
+						resolve(handler as EventListener);
+					}
+				});
+			statusChangeValuePromise = firstValueFrom(
+				new NetworkHealthStatusService().statusChanged$.pipe(skip(1)),
+			);
+		});
+
+		onlineHandler(new Event('online'));
+		await expect(statusChangeValuePromise!).resolves.toBe(true);
+	});
+});

--- a/libs/spa/service-health/src/lib/network-health-staus.service.ts
+++ b/libs/spa/service-health/src/lib/network-health-staus.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import {
+	fromEvent,
+	map,
+	merge,
+	Observable,
+	shareReplay,
+	startWith,
+} from 'rxjs';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class NetworkHealthStatusService {
+	readonly statusChanged$: Observable<boolean> = merge(
+		fromEvent(window, 'online').pipe(map(() => true)),
+		fromEvent(window, 'offline').pipe(map(() => false)),
+	).pipe(
+		startWith(navigator.onLine),
+		shareReplay({ bufferSize: 1, refCount: true }),
+	);
+}

--- a/libs/spa/service-health/src/lib/noop-service-health.module.ts
+++ b/libs/spa/service-health/src/lib/noop-service-health.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { SERVICE_HEALTH_SERVICE } from './service-health.service';
+import { of } from 'rxjs';
+
+@NgModule({
+	providers: [
+		{
+			provide: SERVICE_HEALTH_SERVICE,
+			useValue: {
+				serviceStatusChanged$: of(),
+			},
+		},
+	],
+})
+export class NoopServiceHealthModule {}

--- a/libs/spa/service-health/src/lib/service-health.service.ts
+++ b/libs/spa/service-health/src/lib/service-health.service.ts
@@ -1,0 +1,12 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ServiceStatusReport } from './service-status-report.model';
+
+export const SERVICE_HEALTH_SERVICE = new InjectionToken<ServiceHealthService>(
+	'SERVICE_HEALTH_SERVICE',
+);
+
+export interface ServiceHealthService {
+	serviceStatusChanged$: Observable<ServiceStatusReport>;
+}

--- a/libs/spa/service-health/src/lib/service-status-report.model.ts
+++ b/libs/spa/service-health/src/lib/service-status-report.model.ts
@@ -1,0 +1,5 @@
+export interface ServiceStatusReport {
+	status: 'up' | 'down' | 'maintenance' | 'maintenance_scheduled';
+	message: string;
+	url?: string;
+}

--- a/libs/spa/service-health/src/test-setup.ts
+++ b/libs/spa/service-health/src/test-setup.ts
@@ -1,0 +1,9 @@
+import 'jest-preset-angular/setup-jest';
+
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+	testEnvironmentOptions: {
+		errorOnUnknownElements: true,
+		errorOnUnknownProperties: true,
+	},
+};

--- a/libs/spa/service-health/tsconfig.json
+++ b/libs/spa/service-health/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/spa/service-health/tsconfig.lib.json
+++ b/libs/spa/service-health/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"declarationMap": true,
+		"inlineSources": true,
+		"types": []
+	},
+	"exclude": [
+		"src/**/*.spec.ts",
+		"src/test-setup.ts",
+		"jest.config.ts",
+		"src/**/*.test.ts"
+	],
+	"include": ["src/**/*.ts", "../../../reset.d.ts"]
+}

--- a/libs/spa/service-health/tsconfig.spec.json
+++ b/libs/spa/service-health/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"module": "commonjs",
+		"target": "es2016",
+		"types": ["jest", "node"]
+	},
+	"files": ["src/test-setup.ts"],
+	"include": [
+		"jest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts"
+	]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,8 @@
 			"@kordis/api/test-helpers": ["libs/api/test-helpers/src/index.ts"],
 			"@kordis/shared/auth": ["libs/shared/auth/src/index.ts"],
 			"@kordis/spa/auth": ["libs/spa/auth/src/index.ts"],
-			"@kordis/spa/observability": ["libs/spa/observability/src/index.ts"]
+			"@kordis/spa/observability": ["libs/spa/observability/src/index.ts"],
+			"@kordis/spa/service-health": ["libs/spa/service-health/src/index.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
# Description

This PR introduces a service health service that checks with for changes of our [Instatus](https://kordis.instatus.com/) Dashboard. We can set a status and schedule maintenances via Instatus for our Services as well as with 3rd party services such as Azure AD or HPA services. The checks are performed every 30 seconds in a Webworker, and only new incidents/maintenances or status changes will be emitted. Future work should contain notification components.

# Checklist:

- [ ] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [ ] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
- [x] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [x] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
