### PR TITLE
ci(spa): generate 3rd party licenses in build action

### DIFF
--- a/.github/actions/build-and-deploy-spa/action.yml
+++ b/.github/actions/build-and-deploy-spa/action.yml
@@ -31,6 +31,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Generate Third-Party Licenses
+      run: npx  --yes generate-license-file@3.0.0-beta.1 --input package.json --output apps/spa/src/assets/third-party-licenses.txt --ci
+      shell: bash
     - run: |
         envsubst < apps/spa/src/environments/environment.template > apps/spa/src/environments/environment.prod.ts
         npx nx build spa --prod


### PR DESCRIPTION
We discussed that we want to include the licenses of the packages in our SPA distribution. This PR adds a build step in CI to generate a `.txt` with licenses from ALL packages of the roots `package.json`. Later on, we can just link it somewhere in the SPA. With this, we are definitely on the safe side.