### PR TITLE
chore(spa): support only last 2 major versions of chromium based browsers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,11 @@ Please try to stick to this as much as possible. You can serve the SPA with
 you will get redirected to a login page where you can choose a persona. This
 will set a JWT in the local storage.
 
+We agreed on supporting only Chromium based browsers with their 2 latest major
+versions. This allows us to use features that are available for these browsers
+regardless of their support in other browsers. Therefore, please use Chrome or
+Edge for development.
+
 ### API
 
 The API is a NestJS application serving a GraphQL API. Please use the NX CLI to

--- a/apps/spa/.browserslistrc
+++ b/apps/spa/.browserslistrc
@@ -1,0 +1,2 @@
+last 2 Chrome major version
+last 2 Edge major versions

--- a/apps/spa/src/index.html
+++ b/apps/spa/src/index.html
@@ -1,30 +1,32 @@
 <!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<title>Kordis</title>
-	<base href="/" />
-	<meta content="width=device-width, initial-scale=1" name="viewport" />
-	<link href="favicon.ico" rel="icon" type="image/x-icon" />
-	<script>
-		if (navigator.userAgent.indexOf("Chrome") < 0) {
-			alert("Kordis ist für Chrome optimiert. In anderen Browsern kann es zu Fehlern kommen. Bitte verwenden sie daher die letzte Chrome Version!");
-		}
-	</script>
-</head>
-<body>
-<kordis-root>
-	<div class="flex h-screen items-center justify-center">
-		<div
-			class="inline-block h-28 w-28 animate-spin rounded-full border-8 border-solid border-current border-r-transparent align-[-0.125em] text-blue-500 motion-reduce:animate-[spin_1.5s_linear_infinite]"
-			role="status"
-		>
+	<head>
+		<meta charset="utf-8" />
+		<title>Kordis</title>
+		<base href="/" />
+		<meta content="width=device-width, initial-scale=1" name="viewport" />
+		<link href="favicon.ico" rel="icon" type="image/x-icon" />
+		<script>
+			if (navigator.userAgent.indexOf('Chrome') < 0) {
+				alert(
+					'Kordis ist für Chrome optimiert. In anderen Browsern kann es zu Fehlern kommen. Bitte verwenden sie daher die letzte Chrome Version!',
+				);
+			}
+		</script>
+	</head>
+	<body>
+		<kordis-root>
+			<div class="flex h-screen items-center justify-center">
+				<div
+					class="inline-block h-28 w-28 animate-spin rounded-full border-8 border-solid border-current border-r-transparent align-[-0.125em] text-blue-500 motion-reduce:animate-[spin_1.5s_linear_infinite]"
+					role="status"
+				>
 					<span
 						class="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
-					>Laden...</span
+						>Laden...</span
 					>
-		</div>
-	</div>
-</kordis-root>
-</body>
+				</div>
+			</div>
+		</kordis-root>
+	</body>
 </html>

--- a/apps/spa/src/index.html
+++ b/apps/spa/src/index.html
@@ -1,25 +1,30 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<title>Kordis</title>
-		<base href="/" />
-		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<link href="favicon.ico" rel="icon" type="image/x-icon" />
-	</head>
-	<body>
-		<kordis-root>
-			<div class="flex h-screen items-center justify-center">
-				<div
-					class="inline-block h-28 w-28 animate-spin rounded-full border-8 border-solid border-current border-r-transparent align-[-0.125em] text-blue-500 motion-reduce:animate-[spin_1.5s_linear_infinite]"
-					role="status"
-				>
+<head>
+	<meta charset="utf-8" />
+	<title>Kordis</title>
+	<base href="/" />
+	<meta content="width=device-width, initial-scale=1" name="viewport" />
+	<link href="favicon.ico" rel="icon" type="image/x-icon" />
+	<script>
+		if (navigator.userAgent.indexOf("Chrome") < 0) {
+			alert("Kordis ist für Chrome optimiert. In anderen Browsern kann es zu Fehlern kommen. Bitte verwenden sie daher die letzte Chrome Version!");
+		}
+	</script>
+</head>
+<body>
+<kordis-root>
+	<div class="flex h-screen items-center justify-center">
+		<div
+			class="inline-block h-28 w-28 animate-spin rounded-full border-8 border-solid border-current border-r-transparent align-[-0.125em] text-blue-500 motion-reduce:animate-[spin_1.5s_linear_infinite]"
+			role="status"
+		>
 					<span
 						class="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]"
-						>Laden...</span
+					>Laden...</span
 					>
-				</div>
-			</div>
-		</kordis-root>
-	</body>
+		</div>
+	</div>
+</kordis-root>
+</body>
 </html>

--- a/docs/architecture-decisions/adr008-browser-support.md
+++ b/docs/architecture-decisions/adr008-browser-support.md
@@ -1,0 +1,37 @@
+# ADR008: Browser Support
+
+## Status
+
+Accepted
+
+## Context
+
+Our legacy application has been experiencing issues with Firefox and other
+non-Chromium browsers. These issues have been causing delays in development and
+have been a source of bugs that are hard to track and fix. Moreover, we want to
+leverage the latest web features such as CSS nesting, which are best supported
+and regularly updated in Chromium browsers. Supporting only the latest 2
+versions of Chromium browsers (Chrome and Edge) will allow us to focus our
+efforts on a more narrow range of browsers, reducing the complexity of our
+development and testing processes.
+
+## Decision
+
+We will only officially support the latest 2 versions of Chromium browsers
+(Chrome and Edge). This means that while the application may still work in other
+browsers, we will not be spending resources on testing and fixing issues that
+are specific to those browsers.
+
+## Consequences
+
+- Development will be easier as we only need to consider the latest 2 versions
+  of Chromium browsers.
+- We can leverage the latest web features that are best supported in Chromium
+  browsers.
+- We will need to test the application in the latest 2 versions of Chromium
+  browsers.
+  [This is not possible with Playwright, which always tests against the latest stable version](https://github.com/microsoft/playwright/issues/14435).
+  Therefore, a small possibility of bugs in older versions remains.
+- Users using other browsers may experience issues.
+- We will need to clearly communicate this decision to our users and update our
+  documentation accordingly.


### PR DESCRIPTION
# Description

Check ADR for reasoning. NX specifies in their [docs](https://nx.dev/recipes/tips-n-tricks/browser-support), that they rely on browserlist configs. Also check Angular's [browser support](https://angular.io/guide/browser-support).
# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
