### PR TITLE
chore: add consistent type import linting rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,8 @@
 					{
 						"allowExpressions": true
 					}
-				]
+				],
+				"@typescript-eslint/consistent-type-imports": "error"
 			}
 		},
 		{

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { classes } from '@automapper/classes';
-import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
+import type { ApolloDriverConfig } from '@nestjs/apollo';
+import { ApolloDriver } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
@@ -13,7 +14,7 @@ import {
 	SentryObservabilityModule,
 } from '@kordis/api/observability';
 import { OrganizationModule } from '@kordis/api/organization';
-import { SharedKernel, errorFormatterFactory } from '@kordis/api/shared';
+import { errorFormatterFactory, SharedKernel } from '@kordis/api/shared';
 
 import { AppResolver } from './app.resolver';
 import { AppService } from './app.service';

--- a/apps/api/src/app/app.resolver.ts
+++ b/apps/api/src/app/app.resolver.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType, Query, Resolver } from '@nestjs/graphql';
 
-import { AppService } from './app.service';
+import type { AppService } from './app.service';
 
 @ObjectType()
 export class AppData {

--- a/apps/api/src/app/controllers/graphql-subscriptions.controller.spec.ts
+++ b/apps/api/src/app/controllers/graphql-subscriptions.controller.spec.ts
@@ -1,10 +1,11 @@
 import { createMock } from '@golevelup/ts-jest';
 import { ServiceUnavailableException } from '@nestjs/common';
 import { GraphQLSchemaHost } from '@nestjs/graphql';
-import { Test, TestingModule } from '@nestjs/testing';
-import { Response } from 'express';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import type { Response } from 'express';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 
 import { GraphqlSubscriptionsController } from './graphql-subscriptions.controller';
 

--- a/apps/api/src/app/controllers/graphql-subscriptions.controller.ts
+++ b/apps/api/src/app/controllers/graphql-subscriptions.controller.ts
@@ -1,12 +1,12 @@
+import type { OnModuleInit } from '@nestjs/common';
 import {
 	Controller,
-	OnModuleInit,
 	Post,
 	Req,
 	Res,
 	ServiceUnavailableException,
 } from '@nestjs/common';
-import { GraphQLSchemaHost } from '@nestjs/graphql';
+import type { GraphQLSchemaHost } from '@nestjs/graphql';
 import type { Response } from 'express';
 import { createHandler } from 'graphql-sse/lib/use/express';
 

--- a/apps/spa-e2e/src/auth.setup.ts
+++ b/apps/spa-e2e/src/auth.setup.ts
@@ -1,7 +1,8 @@
 import { test as setup } from '@playwright/test';
 
 import { LoginPo } from './page-objects/login.po';
-import { TestUsernames, getAuthStoragePath, testUsernames } from './test-users';
+import type { TestUsernames } from './test-users';
+import { getAuthStoragePath, testUsernames } from './test-users';
 
 // Documentation: https://playwright.dev/docs/auth#multiple-signed-in-roles
 

--- a/apps/spa-e2e/src/page-objects/login.po.ts
+++ b/apps/spa-e2e/src/page-objects/login.po.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 import { testIdSelector } from '../helper';
 

--- a/apps/spa/src/app/routes.ts
+++ b/apps/spa/src/app/routes.ts
@@ -1,4 +1,4 @@
-import { Routes } from '@angular/router';
+import type { Routes } from '@angular/router';
 
 import { authGuard } from '@kordis/spa/auth';
 

--- a/apps/spa/src/environments/environment.model.ts
+++ b/apps/spa/src/environments/environment.model.ts
@@ -1,4 +1,4 @@
-import { AuthConfig } from 'angular-oauth2-oidc';
+import type { AuthConfig } from 'angular-oauth2-oidc';
 
 export type Environment = {
 	production: boolean;

--- a/apps/spa/src/environments/environment.ts
+++ b/apps/spa/src/environments/environment.ts
@@ -1,4 +1,4 @@
-import { Environment } from './environment.model';
+import type { Environment } from './environment.model';
 
 export const environment: Environment = {
 	production: false,

--- a/libs/api/auth/src/lib/auth-user-extractor-strategies/auth-user-extractor.strategy.ts
+++ b/libs/api/auth/src/lib/auth-user-extractor-strategies/auth-user-extractor.strategy.ts
@@ -1,6 +1,6 @@
-import { Request } from 'express';
+import type { Request } from 'express';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 export abstract class AuthUserExtractorStrategy {
 	abstract getUserFromRequest(req: Request): AuthUser | null;

--- a/libs/api/auth/src/lib/auth-user-extractor-strategies/extract-user-from-ms-principle-header.spec.ts
+++ b/libs/api/auth/src/lib/auth-user-extractor-strategies/extract-user-from-ms-principle-header.spec.ts
@@ -1,11 +1,9 @@
 import { createMock } from '@golevelup/ts-jest';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 
-import {
-	AuthUserExtractorStrategy,
-	ExtractUserFromMsPrincipleHeader,
-} from './auth-user-extractor.strategy';
+import type { AuthUserExtractorStrategy } from './auth-user-extractor.strategy';
+import { ExtractUserFromMsPrincipleHeader } from './auth-user-extractor.strategy';
 
 describe('ExtractUserFromMsPrincipleHeader', () => {
 	let extractStrat: AuthUserExtractorStrategy;

--- a/libs/api/auth/src/lib/decorators/user.decorator.spec.ts
+++ b/libs/api/auth/src/lib/decorators/user.decorator.spec.ts
@@ -1,11 +1,11 @@
 import { createMock } from '@golevelup/ts-jest';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 import {
 	createGqlContextForRequest,
 	createParamDecoratorFactory,
 } from '@kordis/api/test-helpers';
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 import { User } from './user.decorator';
 

--- a/libs/api/auth/src/lib/decorators/user.decorator.ts
+++ b/libs/api/auth/src/lib/decorators/user.decorator.ts
@@ -1,7 +1,8 @@
-import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { createParamDecorator } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 
-import { KordisGqlContext } from '@kordis/api/shared';
+import type { KordisGqlContext } from '@kordis/api/shared';
 
 export const User = createParamDecorator((_: never, ctx: ExecutionContext) => {
 	const req =

--- a/libs/api/auth/src/lib/interceptors/auth.interceptor.spec.ts
+++ b/libs/api/auth/src/lib/interceptors/auth.interceptor.spec.ts
@@ -1,10 +1,12 @@
 import { createMock } from '@golevelup/ts-jest';
-import { CallHandler, UnauthorizedException } from '@nestjs/common';
-import { Observable, firstValueFrom, of } from 'rxjs';
+import type { CallHandler } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
+import type { Observable } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 import { createGqlContextForRequest } from '@kordis/api/test-helpers';
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 import { AuthUserExtractorStrategy } from '../auth-user-extractor-strategies/auth-user-extractor.strategy';
 import { AuthInterceptor } from './auth.interceptor';

--- a/libs/api/auth/src/lib/interceptors/auth.interceptor.ts
+++ b/libs/api/auth/src/lib/interceptors/auth.interceptor.ts
@@ -1,18 +1,18 @@
-import {
+import type {
 	CallHandler,
 	ExecutionContext,
-	Injectable,
-	Logger,
 	NestInterceptor,
-	UnauthorizedException,
 } from '@nestjs/common';
-import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
-import { Observable, throwError } from 'rxjs';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import type { GqlContextType } from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import type { Observable } from 'rxjs';
+import { throwError } from 'rxjs';
 
-import { KordisLogger } from '@kordis/api/observability';
-import { KordisGqlContext, KordisRequest } from '@kordis/api/shared';
+import type { KordisLogger } from '@kordis/api/observability';
+import type { KordisGqlContext, KordisRequest } from '@kordis/api/shared';
 
-import { AuthUserExtractorStrategy } from '../auth-user-extractor-strategies/auth-user-extractor.strategy';
+import type { AuthUserExtractorStrategy } from '../auth-user-extractor-strategies/auth-user-extractor.strategy';
 
 @Injectable()
 export class AuthInterceptor implements NestInterceptor {

--- a/libs/api/observability/src/lib/filters/sentry-exceptions.filter.ts
+++ b/libs/api/observability/src/lib/filters/sentry-exceptions.filter.ts
@@ -1,4 +1,5 @@
-import { Catch, ExceptionFilter } from '@nestjs/common';
+import type { ExceptionFilter } from '@nestjs/common';
+import { Catch } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 
 import { PresentableException } from '@kordis/api/shared';

--- a/libs/api/observability/src/lib/interceptors/sentry-otel-user-context.interceptor.spec.ts
+++ b/libs/api/observability/src/lib/interceptors/sentry-otel-user-context.interceptor.spec.ts
@@ -1,12 +1,14 @@
 import { createMock } from '@golevelup/ts-jest';
-import { CallHandler } from '@nestjs/common/interfaces';
-import { Span, trace } from '@opentelemetry/api';
+import type { CallHandler } from '@nestjs/common/interfaces';
+import type { Span } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
-import { Observable, firstValueFrom, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 import { createGqlContextForRequest } from '@kordis/api/test-helpers';
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 import { SentryOTelUserContextInterceptor } from './sentry-otel-user-context.interceptor';
 

--- a/libs/api/observability/src/lib/interceptors/sentry-otel-user-context.interceptor.ts
+++ b/libs/api/observability/src/lib/interceptors/sentry-otel-user-context.interceptor.ts
@@ -1,15 +1,15 @@
-import {
+import type {
 	CallHandler,
 	ExecutionContext,
-	Injectable,
 	NestInterceptor,
 } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-import { KordisGqlContext } from '@kordis/api/shared';
+import type { KordisGqlContext } from '@kordis/api/shared';
 
 @Injectable()
 export class SentryOTelUserContextInterceptor implements NestInterceptor {

--- a/libs/api/observability/src/lib/oTelSdk.ts
+++ b/libs/api/observability/src/lib/oTelSdk.ts
@@ -1,8 +1,5 @@
-import {
-	NoopOTelSDKFactory,
-	OTelSDKFactory,
-	SentryOTelSDKFactory,
-} from './oTel.factory';
+import type { OTelSDKFactory } from './oTel.factory';
+import { NoopOTelSDKFactory, SentryOTelSDKFactory } from './oTel.factory';
 
 /**
  * this file has to be the first import of the bootstrap file! otherwise the oTel sdk will not be initialized correctly.

--- a/libs/api/observability/src/lib/sentry-observability.module.ts
+++ b/libs/api/observability/src/lib/sentry-observability.module.ts
@@ -1,6 +1,8 @@
-import { Logger, Module, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { APP_FILTER, APP_INTERCEPTOR, ModulesContainer } from '@nestjs/core';
+import type { OnModuleInit } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { ModulesContainer } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { init as initSentry } from '@sentry/node';
 import { ProfilingIntegration } from '@sentry/profiling-node';
 
@@ -8,7 +10,7 @@ import { SentryExceptionsFilter } from './filters/sentry-exceptions.filter';
 import { SentryOTelUserContextInterceptor } from './interceptors/sentry-otel-user-context.interceptor';
 import oTelSDK from './oTelSdk';
 import { KORDIS_LOGGER_SERVICE } from './services/kordis-logger-service.interface';
-import { KordisLogger } from './services/kordis-logger.interface';
+import type { KordisLogger } from './services/kordis-logger.interface';
 import { KordisLoggerImpl } from './services/kordis.logger';
 import { SentryLogger } from './services/sentry-logger.service';
 import { wrapProvidersWithTracingSpans } from './trace-wrapper';

--- a/libs/api/observability/src/lib/services/kordis-logger-service.interface.ts
+++ b/libs/api/observability/src/lib/services/kordis-logger-service.interface.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 
 export const KORDIS_LOGGER_SERVICE = Symbol('KORDIS_LOGGER_SERVICE');
 

--- a/libs/api/observability/src/lib/services/kordis-logger.interface.ts
+++ b/libs/api/observability/src/lib/services/kordis-logger.interface.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 
 export interface KordisLogger extends LoggerService {
 	log(message: string, args?: object): void;

--- a/libs/api/observability/src/lib/services/kordis.logger.spec.ts
+++ b/libs/api/observability/src/lib/services/kordis.logger.spec.ts
@@ -1,6 +1,6 @@
 import { createMock } from '@golevelup/ts-jest';
 
-import { KordisLoggerService } from './kordis-logger-service.interface';
+import type { KordisLoggerService } from './kordis-logger-service.interface';
 import { KordisLoggerImpl } from './kordis.logger';
 
 describe('KordisLoggerImpl', () => {

--- a/libs/api/observability/src/lib/services/kordis.logger.ts
+++ b/libs/api/observability/src/lib/services/kordis.logger.ts
@@ -1,10 +1,9 @@
-import { Inject, LoggerService } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
+import { Inject } from '@nestjs/common';
 
-import {
-	KORDIS_LOGGER_SERVICE,
-	KordisLoggerService,
-} from './kordis-logger-service.interface';
-import { KordisLogger } from './kordis-logger.interface';
+import type { KordisLoggerService } from './kordis-logger-service.interface';
+import { KORDIS_LOGGER_SERVICE } from './kordis-logger-service.interface';
+import type { KordisLogger } from './kordis-logger.interface';
 
 export class KordisLoggerImpl implements LoggerService, KordisLogger {
 	constructor(

--- a/libs/api/observability/src/lib/services/pino-logger.service.ts
+++ b/libs/api/observability/src/lib/services/pino-logger.service.ts
@@ -1,9 +1,9 @@
 import pino from 'pino';
-import { OnUnknown } from 'pino-abstract-transport';
+import type { OnUnknown } from 'pino-abstract-transport';
 import pretty from 'pino-pretty';
-import { Transform } from 'stream';
+import type { Transform } from 'stream';
 
-import { KordisLoggerService } from './kordis-logger-service.interface';
+import type { KordisLoggerService } from './kordis-logger-service.interface';
 
 /*
  * This logger is used for logging with pino to the console. If debug is set to false, it will only log info and above as json output, otherwise as a pretty print.

--- a/libs/api/observability/src/lib/trace-wrapper.ts
+++ b/libs/api/observability/src/lib/trace-wrapper.ts
@@ -1,10 +1,10 @@
-import { ModulesContainer } from '@nestjs/core';
+import type { ModulesContainer } from '@nestjs/core';
 
+import type { TraceWrapper } from './trace-wrappers';
 import {
 	InterceptorTraceWrapper,
 	ResolverTraceWrapper,
 	TraceDecoratorTraceWrapper,
-	TraceWrapper,
 } from './trace-wrappers';
 
 // this has to be called from a NestJS import (main.ts or any provider/module) context, otherwise prototypes are not correctly patched

--- a/libs/api/observability/src/lib/trace-wrappers/abstract-trace-wrapper.ts
+++ b/libs/api/observability/src/lib/trace-wrappers/abstract-trace-wrapper.ts
@@ -1,5 +1,6 @@
-import { MetadataScanner, ModulesContainer } from '@nestjs/core';
-import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import type { ModulesContainer } from '@nestjs/core';
+import { MetadataScanner } from '@nestjs/core';
+import type { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { trace } from '@opentelemetry/api';
 
 export abstract class TraceWrapper {

--- a/libs/api/observability/src/lib/trace-wrappers/interceptor-trace-wrapper.spec.ts
+++ b/libs/api/observability/src/lib/trace-wrappers/interceptor-trace-wrapper.spec.ts
@@ -1,13 +1,14 @@
 import { createMock } from '@golevelup/ts-jest';
-import {
+import type {
 	CallHandler,
 	ExecutionContext,
-	Injectable,
 	NestInterceptor,
 } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { APP_INTERCEPTOR, ModulesContainer } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
-import { Observable, firstValueFrom, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
 import {
 	createTraceMocks,

--- a/libs/api/observability/src/lib/trace-wrappers/interceptor-trace-wrapper.ts
+++ b/libs/api/observability/src/lib/trace-wrappers/interceptor-trace-wrapper.ts
@@ -1,4 +1,4 @@
-import { ModulesContainer } from '@nestjs/core';
+import type { ModulesContainer } from '@nestjs/core';
 
 import { TraceWrapper } from './abstract-trace-wrapper';
 

--- a/libs/api/observability/src/lib/trace-wrappers/resolver-trace-wrapper.ts
+++ b/libs/api/observability/src/lib/trace-wrappers/resolver-trace-wrapper.ts
@@ -1,5 +1,5 @@
-import { ModulesContainer } from '@nestjs/core';
-import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import type { ModulesContainer } from '@nestjs/core';
+import type { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import {
 	RESOLVER_NAME_METADATA,
 	RESOLVER_TYPE_METADATA,

--- a/libs/api/observability/src/lib/trace-wrappers/trace-decorator-trace-wrapper.ts
+++ b/libs/api/observability/src/lib/trace-wrappers/trace-decorator-trace-wrapper.ts
@@ -1,5 +1,5 @@
-import { ModulesContainer } from '@nestjs/core';
-import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import type { ModulesContainer } from '@nestjs/core';
+import type { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 
 import { SPAN_ACTIVE, TRACE_NAME } from '../decorators/trace.decorator';
 import { TraceWrapper } from './abstract-trace-wrapper';

--- a/libs/api/organization/src/lib/core/command/create-organization.command.ts
+++ b/libs/api/organization/src/lib/core/command/create-organization.command.ts
@@ -1,17 +1,14 @@
 import { Inject, Logger } from '@nestjs/common';
-import { CommandHandler, EventBus, ICommandHandler } from '@nestjs/cqrs';
+import type { EventBus, ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler } from '@nestjs/cqrs';
 
 import type { KordisLogger } from '@kordis/api/observability';
 
-import {
-	Organization,
-	OrganizationGeoSettings,
-} from '../entity/organization.entity';
+import type { OrganizationGeoSettings } from '../entity/organization.entity';
+import { Organization } from '../entity/organization.entity';
 import { OrganizationCreatedEvent } from '../event/organization-created.event';
-import {
-	ORGANIZATION_REPOSITORY,
-	OrganizationRepository,
-} from '../repository/organization.repository';
+import type { OrganizationRepository } from '../repository/organization.repository';
+import { ORGANIZATION_REPOSITORY } from '../repository/organization.repository';
 
 export class CreateOrganizationCommand {
 	constructor(

--- a/libs/api/organization/src/lib/core/command/update-organization-geo-settings.command.spec.ts
+++ b/libs/api/organization/src/lib/core/command/update-organization-geo-settings.command.spec.ts
@@ -1,13 +1,11 @@
 import { createMock } from '@golevelup/ts-jest';
-import { EventBus } from '@nestjs/cqrs';
+import type { EventBus } from '@nestjs/cqrs';
 
-import {
-	Organization,
-	OrganizationGeoSettings,
-} from '../entity/organization.entity';
+import type { OrganizationGeoSettings } from '../entity/organization.entity';
+import { Organization } from '../entity/organization.entity';
 import { OrganizationGeoSettingsUpdatedEvent } from '../event/organization-geo-settings-updated.event';
 import { OrganizationNotFoundException } from '../exceptions/organization-not-found.exception';
-import { OrganizationRepository } from '../repository/organization.repository';
+import type { OrganizationRepository } from '../repository/organization.repository';
 import {
 	UpdateOrganizationGeoSettingsCommand,
 	UpdateOrganizationGeoSettingsHandler,

--- a/libs/api/organization/src/lib/core/command/update-organization-geo-settings.command.ts
+++ b/libs/api/organization/src/lib/core/command/update-organization-geo-settings.command.ts
@@ -1,18 +1,17 @@
 import { Inject, Logger } from '@nestjs/common';
-import { CommandHandler, EventBus, ICommandHandler } from '@nestjs/cqrs';
+import type { EventBus, ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler } from '@nestjs/cqrs';
 
-import { KordisLogger } from '@kordis/api/observability';
+import type { KordisLogger } from '@kordis/api/observability';
 
-import {
+import type {
 	Organization,
 	OrganizationGeoSettings,
 } from '../entity/organization.entity';
 import { OrganizationGeoSettingsUpdatedEvent } from '../event/organization-geo-settings-updated.event';
 import { OrganizationNotFoundException } from '../exceptions/organization-not-found.exception';
-import {
-	ORGANIZATION_REPOSITORY,
-	OrganizationRepository,
-} from '../repository/organization.repository';
+import type { OrganizationRepository } from '../repository/organization.repository';
+import { ORGANIZATION_REPOSITORY } from '../repository/organization.repository';
 
 export class UpdateOrganizationGeoSettingsCommand {
 	constructor(

--- a/libs/api/organization/src/lib/core/entity/bbox.validator.ts
+++ b/libs/api/organization/src/lib/core/entity/bbox.validator.ts
@@ -1,9 +1,7 @@
-import {
-	ValidatorConstraint,
-	ValidatorConstraintInterface,
-} from 'class-validator';
+import type { ValidatorConstraintInterface } from 'class-validator';
+import { ValidatorConstraint } from 'class-validator';
 
-import { BBox } from './organization.entity';
+import type { BBox } from './organization.entity';
 
 @ValidatorConstraint()
 export class IsBBox implements ValidatorConstraintInterface {

--- a/libs/api/organization/src/lib/core/event/organization-created.event.ts
+++ b/libs/api/organization/src/lib/core/event/organization-created.event.ts
@@ -1,4 +1,4 @@
-import { Organization } from '../entity/organization.entity';
+import type { Organization } from '../entity/organization.entity';
 
 export class OrganizationCreatedEvent {
 	constructor(public readonly org: Organization) {}

--- a/libs/api/organization/src/lib/core/event/organization-geo-settings-updated.event.ts
+++ b/libs/api/organization/src/lib/core/event/organization-geo-settings-updated.event.ts
@@ -1,4 +1,4 @@
-import { OrganizationGeoSettings } from '../entity/organization.entity';
+import type { OrganizationGeoSettings } from '../entity/organization.entity';
 
 export class OrganizationGeoSettingsUpdatedEvent {
 	constructor(

--- a/libs/api/organization/src/lib/core/query/get-organization.query.spec.ts
+++ b/libs/api/organization/src/lib/core/query/get-organization.query.spec.ts
@@ -1,14 +1,12 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
 
-import { Mutable } from '@kordis/api/shared';
+import type { Mutable } from '@kordis/api/shared';
 
 import { Organization } from '../entity/organization.entity';
 import { OrganizationNotFoundException } from '../exceptions/organization-not-found.exception';
-import {
-	ORGANIZATION_REPOSITORY,
-	OrganizationRepository,
-} from '../repository/organization.repository';
+import type { OrganizationRepository } from '../repository/organization.repository';
+import { ORGANIZATION_REPOSITORY } from '../repository/organization.repository';
 import {
 	GetOrganizationHandler,
 	GetOrganizationQuery,

--- a/libs/api/organization/src/lib/core/query/get-organization.query.ts
+++ b/libs/api/organization/src/lib/core/query/get-organization.query.ts
@@ -1,12 +1,11 @@
 import { Inject } from '@nestjs/common';
-import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import type { IQueryHandler } from '@nestjs/cqrs';
+import { QueryHandler } from '@nestjs/cqrs';
 
-import { Organization } from '../entity/organization.entity';
+import type { Organization } from '../entity/organization.entity';
 import { OrganizationNotFoundException } from '../exceptions/organization-not-found.exception';
-import {
-	ORGANIZATION_REPOSITORY,
-	OrganizationRepository,
-} from '../repository/organization.repository';
+import type { OrganizationRepository } from '../repository/organization.repository';
+import { ORGANIZATION_REPOSITORY } from '../repository/organization.repository';
 
 export class GetOrganizationQuery {
 	constructor(public readonly id: string) {}

--- a/libs/api/organization/src/lib/core/repository/organization.repository.ts
+++ b/libs/api/organization/src/lib/core/repository/organization.repository.ts
@@ -1,4 +1,4 @@
-import { Organization } from '../entity/organization.entity';
+import type { Organization } from '../entity/organization.entity';
 
 export const ORGANIZATION_REPOSITORY = Symbol('OrganizationRepository');
 

--- a/libs/api/organization/src/lib/infra/controller/organization.resolver.spec.ts
+++ b/libs/api/organization/src/lib/infra/controller/organization.resolver.spec.ts
@@ -1,9 +1,11 @@
-import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import type { DeepMocked } from '@golevelup/ts-jest';
+import { createMock } from '@golevelup/ts-jest';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 
+import type { Mutable } from '@kordis/api/shared';
 import {
-	Mutable,
 	PresentableNotFoundException,
 	PresentableValidationException,
 	ValidationException,
@@ -11,10 +13,8 @@ import {
 
 import { CreateOrganizationCommand } from '../../core/command/create-organization.command';
 import { UpdateOrganizationGeoSettingsCommand } from '../../core/command/update-organization-geo-settings.command';
-import {
-	Organization,
-	OrganizationGeoSettings,
-} from '../../core/entity/organization.entity';
+import type { OrganizationGeoSettings } from '../../core/entity/organization.entity';
+import { Organization } from '../../core/entity/organization.entity';
 import { OrganizationNotFoundException } from '../../core/exceptions/organization-not-found.exception';
 import { OrganizationResolver } from './organization.resolver';
 

--- a/libs/api/organization/src/lib/infra/controller/organization.resolver.ts
+++ b/libs/api/organization/src/lib/infra/controller/organization.resolver.ts
@@ -1,4 +1,4 @@
-import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import type { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
 import {
@@ -9,10 +9,8 @@ import {
 
 import { CreateOrganizationCommand } from '../../core/command/create-organization.command';
 import { UpdateOrganizationGeoSettingsCommand } from '../../core/command/update-organization-geo-settings.command';
-import {
-	Organization,
-	OrganizationGeoSettings,
-} from '../../core/entity/organization.entity';
+import type { OrganizationGeoSettings } from '../../core/entity/organization.entity';
+import { Organization } from '../../core/entity/organization.entity';
 import { OrganizationNotFoundException } from '../../core/exceptions/organization-not-found.exception';
 import { GetOrganizationQuery } from '../../core/query/get-organization.query';
 

--- a/libs/api/organization/src/lib/infra/repository/organization.repository.ts
+++ b/libs/api/organization/src/lib/infra/repository/organization.repository.ts
@@ -1,14 +1,12 @@
-import { Mapper } from '@automapper/core';
+import type { Mapper } from '@automapper/core';
 import { Inject } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { getMapperToken } from '@timonmasberg/automapper-nestjs';
-import { Model } from 'mongoose';
+import type { Model } from 'mongoose';
 
-import {
-	Organization,
-	Organization as OrganizationEntity,
-} from '../../core/entity/organization.entity';
-import { OrganizationRepository } from '../../core/repository/organization.repository';
+import type { Organization } from '../../core/entity/organization.entity';
+import { Organization as OrganizationEntity } from '../../core/entity/organization.entity';
+import type { OrganizationRepository } from '../../core/repository/organization.repository';
 import { OrganizationDocument } from '../schema/organization.schema';
 
 export class ImplOrganizationRepository implements OrganizationRepository {

--- a/libs/api/organization/src/lib/infra/repository/organization.respository.spec.ts
+++ b/libs/api/organization/src/lib/infra/repository/organization.respository.spec.ts
@@ -1,11 +1,12 @@
 import { classes } from '@automapper/classes';
-import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import type { DeepMocked } from '@golevelup/ts-jest';
+import { createMock } from '@golevelup/ts-jest';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test } from '@nestjs/testing';
 import { AutomapperModule } from '@timonmasberg/automapper-nestjs';
-import { Model } from 'mongoose';
+import type { Model } from 'mongoose';
 
-import { Mutable } from '@kordis/api/shared';
+import type { Mutable } from '@kordis/api/shared';
 import { mockModelMethodResult } from '@kordis/api/test-helpers';
 
 import { Organization as OrganizationEntity } from '../../core/entity/organization.entity';

--- a/libs/api/shared/src/lib/exceptions/error-formatter.ts
+++ b/libs/api/shared/src/lib/exceptions/error-formatter.ts
@@ -1,6 +1,6 @@
-import { GraphQLFormattedError } from 'graphql/error';
+import type { GraphQLFormattedError } from 'graphql/error';
 
-import GraphqlErrorConvertable from './graphql-error-convertable';
+import type GraphqlErrorConvertable from './graphql-error-convertable';
 import { PresentableUnknownException } from './presentable/presentable-unknown.exception';
 import { PresentableException } from './presentable/presentable.exception';
 

--- a/libs/api/shared/src/lib/exceptions/flatten-class-validation-errors.spec.ts
+++ b/libs/api/shared/src/lib/exceptions/flatten-class-validation-errors.spec.ts
@@ -1,4 +1,4 @@
-import { ValidationExceptionEntry } from './core/validation.exception';
+import type { ValidationExceptionEntry } from './core/validation.exception';
 import { flattenValidationErrors } from './flatten-class-validation-errors';
 
 describe('flattenValidationErrors', () => {

--- a/libs/api/shared/src/lib/exceptions/flatten-class-validation-errors.ts
+++ b/libs/api/shared/src/lib/exceptions/flatten-class-validation-errors.ts
@@ -1,6 +1,6 @@
-import { ValidationError } from 'class-validator';
+import type { ValidationError } from 'class-validator';
 
-import { ValidationExceptionEntry } from './core/validation.exception';
+import type { ValidationExceptionEntry } from './core/validation.exception';
 
 export function flattenValidationErrors(
 	errors: ValidationError[],

--- a/libs/api/shared/src/lib/exceptions/graphql-error-convertable.ts
+++ b/libs/api/shared/src/lib/exceptions/graphql-error-convertable.ts
@@ -1,4 +1,4 @@
-import { GraphQLFormattedError } from 'graphql/error';
+import type { GraphQLFormattedError } from 'graphql/error';
 
 export default interface GraphqlErrorConvertable {
 	asGraphQLError(): GraphQLFormattedError;

--- a/libs/api/shared/src/lib/exceptions/presentable/presentable-validation.exception.spec.ts
+++ b/libs/api/shared/src/lib/exceptions/presentable/presentable-validation.exception.spec.ts
@@ -1,9 +1,7 @@
-import { ValidationError } from 'class-validator';
+import type { ValidationError } from 'class-validator';
 
-import {
-	ValidationException,
-	ValidationExceptionEntry,
-} from '../core/validation.exception';
+import type { ValidationExceptionEntry } from '../core/validation.exception';
+import { ValidationException } from '../core/validation.exception';
 import { PresentableValidationException } from '../presentable/presentable-validation.exception';
 
 describe('PresentableValidationException', () => {

--- a/libs/api/shared/src/lib/exceptions/presentable/presentable-validation.exception.ts
+++ b/libs/api/shared/src/lib/exceptions/presentable/presentable-validation.exception.ts
@@ -1,7 +1,7 @@
-import { ValidationError } from 'class-validator';
-import { GraphQLFormattedError } from 'graphql/error';
+import type { ValidationError } from 'class-validator';
+import type { GraphQLFormattedError } from 'graphql/error';
 
-import {
+import type {
 	ValidationException,
 	ValidationExceptionEntry,
 } from '../core/validation.exception';

--- a/libs/api/shared/src/lib/exceptions/presentable/presentable.exception.ts
+++ b/libs/api/shared/src/lib/exceptions/presentable/presentable.exception.ts
@@ -1,6 +1,6 @@
-import { GraphQLFormattedError } from 'graphql/error';
+import type { GraphQLFormattedError } from 'graphql/error';
 
-import GraphqlErrorConvertable from '../graphql-error-convertable';
+import type GraphqlErrorConvertable from '../graphql-error-convertable';
 
 /**
  * Errors are exclusive. Only Errors of type PresentableError will be delivered to external layers.

--- a/libs/api/shared/src/lib/kernel/graphql/subscriptions/graphql-subscription.service.spec.ts
+++ b/libs/api/shared/src/lib/kernel/graphql/subscriptions/graphql-subscription.service.spec.ts
@@ -1,5 +1,6 @@
 import { CqrsModule, EventBus } from '@nestjs/cqrs';
-import { Test, TestingModule } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 
 import { GraphQLSubscriptionService } from './graphql-subscription.service';
 

--- a/libs/api/shared/src/lib/kernel/graphql/subscriptions/graphql-subscription.service.ts
+++ b/libs/api/shared/src/lib/kernel/graphql/subscriptions/graphql-subscription.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, OnModuleDestroy, Type } from '@nestjs/common';
-import { EventBus, IEvent, ofType } from '@nestjs/cqrs';
-import { Observable, Subject, filter, map, share, takeUntil } from 'rxjs';
+import type { OnModuleDestroy, Type } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { EventBus, IEvent } from '@nestjs/cqrs';
+import { ofType } from '@nestjs/cqrs';
+import type { Observable } from 'rxjs';
+import { filter, map, share, Subject, takeUntil } from 'rxjs';
 
 import { observableToAsyncIterable } from './observable-to-asynciterable.helper';
 

--- a/libs/api/shared/src/lib/models/base-document.model.ts
+++ b/libs/api/shared/src/lib/models/base-document.model.ts
@@ -2,7 +2,7 @@ import { AutoMap } from '@automapper/classes';
 import { Prop } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
-import { BaseModel } from './base-entity.model';
+import type { BaseModel } from './base-entity.model';
 
 export abstract class BaseDocument extends Document implements BaseModel {
 	@Prop()

--- a/libs/api/shared/src/lib/models/request.model.ts
+++ b/libs/api/shared/src/lib/models/request.model.ts
@@ -1,6 +1,6 @@
-import { Request } from 'express';
+import type { Request } from 'express';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 export interface KordisGqlContext {
 	req: KordisRequest;

--- a/libs/api/test-helpers/src/lib/execution-context.test-helper.ts
+++ b/libs/api/test-helpers/src/lib/execution-context.test-helper.ts
@@ -1,8 +1,8 @@
 import { createMock } from '@golevelup/ts-jest';
-import { ExecutionContext } from '@nestjs/common';
-import { HttpArgumentsHost } from '@nestjs/common/interfaces';
+import type { ExecutionContext } from '@nestjs/common';
+import type { HttpArgumentsHost } from '@nestjs/common/interfaces';
 
-import { KordisRequest } from '@kordis/api/shared';
+import type { KordisRequest } from '@kordis/api/shared';
 
 export function createGqlContextForRequest(req: KordisRequest) {
 	return createMock<ExecutionContext>({

--- a/libs/api/test-helpers/src/lib/mongo.test-helper.ts
+++ b/libs/api/test-helpers/src/lib/mongo.test-helper.ts
@@ -1,4 +1,4 @@
-import { Model } from 'mongoose';
+import type { Model } from 'mongoose';
 
 export function mockModelMethodResult(
 	model: Model<unknown>,

--- a/libs/api/test-helpers/src/lib/observability.test-helper.ts
+++ b/libs/api/test-helpers/src/lib/observability.test-helper.ts
@@ -1,6 +1,7 @@
 import { createMock } from '@golevelup/ts-jest';
-import { Span, trace } from '@opentelemetry/api';
-import { Tracer } from '@opentelemetry/sdk-trace-base';
+import type { Span } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
+import type { Tracer } from '@opentelemetry/sdk-trace-base';
 
 export function getComparablePrototypeSnapshot(prototype: Record<any, any>) {
 	return JSON.stringify(

--- a/libs/spa/auth/src/lib/auth.module.ts
+++ b/libs/spa/auth/src/lib/auth.module.ts
@@ -1,14 +1,10 @@
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import {
-	APP_INITIALIZER,
-	ModuleWithProviders,
-	NgModule,
-	inject,
-} from '@angular/core';
+import type { ModuleWithProviders } from '@angular/core';
+import { APP_INITIALIZER, inject, NgModule } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
+import type { AuthConfig } from 'angular-oauth2-oidc';
 import {
-	AuthConfig,
 	DefaultOAuthInterceptor,
 	OAuthModule,
 	OAuthService,

--- a/libs/spa/auth/src/lib/components/auth.component.spec.ts
+++ b/libs/spa/auth/src/lib/components/auth.component.spec.ts
@@ -1,4 +1,5 @@
-import { SpectatorRouting, createRoutingFactory } from '@ngneat/spectator/jest';
+import type { SpectatorRouting } from '@ngneat/spectator/jest';
+import { createRoutingFactory } from '@ngneat/spectator/jest';
 
 import { AUTH_SERVICE } from '../services/auth-service';
 import { DevAuthService } from '../services/dev-auth.service';

--- a/libs/spa/auth/src/lib/components/auth.component.ts
+++ b/libs/spa/auth/src/lib/components/auth.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { map, Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { map } from 'rxjs';
 
 import { AUTH_SERVICE, AuthService } from '../services/auth-service';
 

--- a/libs/spa/auth/src/lib/components/dev-login.component.spec.ts
+++ b/libs/spa/auth/src/lib/components/dev-login.component.spec.ts
@@ -1,9 +1,10 @@
 import { ReactiveFormsModule } from '@angular/forms';
 import { createMock } from '@golevelup/ts-jest';
-import { SpectatorRouting, createRoutingFactory } from '@ngneat/spectator/jest';
+import type { SpectatorRouting } from '@ngneat/spectator/jest';
+import { createRoutingFactory } from '@ngneat/spectator/jest';
 
 import { AUTH_SERVICE } from '../services/auth-service';
-import { DevAuthService } from '../services/dev-auth.service';
+import type { DevAuthService } from '../services/dev-auth.service';
 import { DevLoginComponent } from './dev-login.component';
 
 describe('DevLoginComponent', () => {

--- a/libs/spa/auth/src/lib/components/dev-login.component.ts
+++ b/libs/spa/auth/src/lib/components/dev-login.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 import { AUTH_SERVICE } from '../services/auth-service';
 import { DevAuthService } from '../services/dev-auth.service';

--- a/libs/spa/auth/src/lib/dev-auth.module.ts
+++ b/libs/spa/auth/src/lib/dev-auth.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import type { ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 

--- a/libs/spa/auth/src/lib/guards/auth.guard.spec.ts
+++ b/libs/spa/auth/src/lib/guards/auth.guard.spec.ts
@@ -1,14 +1,16 @@
 import { TestBed } from '@angular/core/testing';
-import {
+import type {
 	ActivatedRouteSnapshot,
 	NavigationExtras,
-	Router,
 	RouterStateSnapshot,
 } from '@angular/router';
+import { Router } from '@angular/router';
 import { createMock } from '@golevelup/ts-jest';
-import { Observable, ReplaySubject, Subject, firstValueFrom } from 'rxjs';
+import type { Observable, Subject } from 'rxjs';
+import { firstValueFrom, ReplaySubject } from 'rxjs';
 
-import { AUTH_SERVICE, AuthService } from '../services/auth-service';
+import type { AuthService } from '../services/auth-service';
+import { AUTH_SERVICE } from '../services/auth-service';
 import { authGuard } from './auth.guard';
 
 describe('AuthGuard', () => {

--- a/libs/spa/auth/src/lib/guards/auth.guard.ts
+++ b/libs/spa/auth/src/lib/guards/auth.guard.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import type { CanActivateFn } from '@angular/router';
+import { Router } from '@angular/router';
 import { switchMap } from 'rxjs';
 
 import { AUTH_SERVICE } from '../services/auth-service';

--- a/libs/spa/auth/src/lib/interceptors/dev-auth.interceptor.ts
+++ b/libs/spa/auth/src/lib/interceptors/dev-auth.interceptor.ts
@@ -1,11 +1,12 @@
-import {
+import type {
 	HttpEvent,
 	HttpHandler,
 	HttpInterceptor,
 	HttpRequest,
 } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable, first } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { first } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { AUTH_SERVICE } from '../services/auth-service';

--- a/libs/spa/auth/src/lib/services/auth-service.ts
+++ b/libs/spa/auth/src/lib/services/auth-service.ts
@@ -1,12 +1,14 @@
 import { InjectionToken } from '@angular/core';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
 export interface AuthService {
 	readonly user$: Observable<AuthUser | null>;
 	readonly isAuthenticated$: Observable<boolean>;
+
 	login(): void;
+
 	logout(): void;
 }
 

--- a/libs/spa/auth/src/lib/services/auth.service.spec.ts
+++ b/libs/spa/auth/src/lib/services/auth.service.spec.ts
@@ -1,7 +1,8 @@
-import { SpectatorService } from '@ngneat/spectator';
+import type { SpectatorService } from '@ngneat/spectator';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
-import { OAuthEvent, OAuthService } from 'angular-oauth2-oidc';
-import { Subject, firstValueFrom } from 'rxjs';
+import type { OAuthEvent } from 'angular-oauth2-oidc';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { firstValueFrom, Subject } from 'rxjs';
 
 import { ProdAuthService } from './auth.service';
 

--- a/libs/spa/auth/src/lib/services/auth.service.ts
+++ b/libs/spa/auth/src/lib/services/auth.service.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@angular/core';
 import { OAuthService } from 'angular-oauth2-oidc';
-import {
-	BehaviorSubject,
-	Observable,
-	distinctUntilChanged,
-	map,
-	shareReplay,
-} from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map, shareReplay } from 'rxjs';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
-import { AuthService } from './auth-service';
+import type { AuthService } from './auth-service';
 
 @Injectable()
 export class ProdAuthService implements AuthService {

--- a/libs/spa/auth/src/lib/services/dev-auth.service.spec.ts
+++ b/libs/spa/auth/src/lib/services/dev-auth.service.spec.ts
@@ -1,5 +1,6 @@
 import { Router } from '@angular/router';
-import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
+import type { SpectatorService } from '@ngneat/spectator/jest';
+import { createServiceFactory } from '@ngneat/spectator/jest';
 import { firstValueFrom } from 'rxjs';
 
 import { DevAuthService } from './dev-auth.service';

--- a/libs/spa/auth/src/lib/services/dev-auth.service.ts
+++ b/libs/spa/auth/src/lib/services/dev-auth.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Observable, map } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, map } from 'rxjs';
 
-import { AuthUser } from '@kordis/shared/auth';
+import type { AuthUser } from '@kordis/shared/auth';
 
-import { AuthService } from './auth-service';
+import type { AuthService } from './auth-service';
 
 /**
  * This is a simple implementation of the AuthService which is intended to be used in development.

--- a/libs/spa/observability/src/lib/noop-observability.module.ts
+++ b/libs/spa/observability/src/lib/noop-observability.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import type { ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 
 import {
 	NoopObservabilityService,

--- a/libs/spa/observability/src/lib/sentry-observability.module.ts
+++ b/libs/spa/observability/src/lib/sentry-observability.module.ts
@@ -1,18 +1,14 @@
 import { CommonModule } from '@angular/common';
-import {
-	APP_INITIALIZER,
-	ErrorHandler,
-	ModuleWithProviders,
-	NgModule,
-} from '@angular/core';
+import type { ModuleWithProviders } from '@angular/core';
+import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core';
 import { Router } from '@angular/router';
 import {
 	BrowserTracing,
-	Replay,
-	TraceService,
 	createErrorHandler,
 	init as initSentry,
 	instrumentAngularRouting,
+	Replay,
+	TraceService,
 } from '@sentry/angular-ivy';
 
 import {

--- a/libs/spa/observability/src/lib/services/sentry-observability.service.spec.ts
+++ b/libs/spa/observability/src/lib/services/sentry-observability.service.spec.ts
@@ -1,4 +1,5 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import type { SpectatorService } from '@ngneat/spectator/jest';
+import { createServiceFactory } from '@ngneat/spectator/jest';
 import { AUTH_SERVICE, DevAuthService } from '@kordis/spa/auth';
 
 import { SentryObservabilityService } from './sentry-observability.service';


### PR DESCRIPTION
# Description

This adds @typescript-eslint/consistent-type-imports and fixes it for the project. Explicitly marking type imports has several [advantages](https://stackoverflow.com/questions/61412000/do-i-need-to-use-the-import-type-feature-of-typescript-3-8-if-all-of-my-import).

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
