### PR TITLE
build: use non-root user for API container

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ COPY ./dist/apps/api ./
 # Use distroless for maximum security: https://github.com/GoogleContainerTools/distroless
 FROM gcr.io/distroless/nodejs${NODE_VERSION}-debian12:nonroot
 
-COPY --chown=nonroot --from=builder /app /app
+COPY --chown=nonroot --chmod=500 --from=builder /app /app
 WORKDIR /app
 
 ENV PORT=3333

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,9 +13,9 @@ RUN npm --omit=dev ci
 COPY ./dist/apps/api ./
 
 # Use distroless for maximum security: https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/nodejs${NODE_VERSION}-debian11
+FROM gcr.io/distroless/nodejs${NODE_VERSION}-debian12:nonroot
 
-COPY --from=builder /app /app
+COPY --chown=nonroot --from=builder /app /app
 WORKDIR /app
 
 ENV PORT=3333

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ COPY ./dist/apps/api ./
 # Use distroless for maximum security: https://github.com/GoogleContainerTools/distroless
 FROM gcr.io/distroless/nodejs${NODE_VERSION}-debian12:nonroot
 
-COPY --chown=nonroot --chmod=500 --from=builder /app /app
+COPY --chown=root:root --chmod=655 --from=builder /app /app
 WORKDIR /app
 
 ENV PORT=3333


### PR DESCRIPTION
# Description

Use a non-root user for the API container for security purposes.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [ ] ~~I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.~~
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).