### PR TITLE
fix(spa): dynamic config not available for app module imports

### DIFF
--- a/apps/spa/src/app/app.module.ts
+++ b/apps/spa/src/app/app.module.ts
@@ -1,12 +1,11 @@
 import { registerLocaleData } from '@angular/common';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import de from '@angular/common/locales/de';
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import DOMPurify from 'dompurify';
 import { NZ_I18N, de_DE } from 'ng-zorro-antd/i18n';
-import { firstValueFrom } from 'rxjs';
 
 import { AuthModule, DevAuthModule } from '@kordis/spa/auth';
 import {
@@ -61,15 +60,6 @@ registerLocaleData(de);
 					},
 				});
 			},
-			multi: true,
-		},
-		{
-			provide: APP_INITIALIZER,
-			useFactory: (http: HttpClient) => async () => {
-				const config = await firstValueFrom(http.get('./assets/config.json'));
-				Object.assign(environment, { ...config, ...environment });
-			},
-			deps: [HttpClient],
 			multi: true,
 		},
 		{ provide: NZ_I18N, useValue: de_DE },

--- a/apps/spa/src/environments/dynamic-config.model.ts
+++ b/apps/spa/src/environments/dynamic-config.model.ts
@@ -1,0 +1,11 @@
+import { AuthConfig } from 'angular-oauth2-oidc';
+
+export interface DynamicConfig {
+	environmentName: string;
+	apiUrl: string;
+	sentryKey?: string;
+	oauth?: {
+		config: AuthConfig;
+		discoveryDocumentUrl: string;
+	};
+}

--- a/apps/spa/src/environments/environment.ts
+++ b/apps/spa/src/environments/environment.ts
@@ -1,18 +1,9 @@
-import { AuthConfig } from 'angular-oauth2-oidc';
+import { DynamicConfig } from './dynamic-config.model';
 
 export const environment = {
 	production: false,
-
 	releaseVersion: '0.0.0-development',
 } as {
 	production: boolean;
 	releaseVersion: string;
-	// following properties are from the runtime dependent assets/config.json
-	environmentName: string;
-	apiUrl: string;
-	sentryKey?: string;
-	oauth?: {
-		config: AuthConfig;
-		discoveryDocumentUrl: string;
-	};
-};
+} & DynamicConfig; // DynamicConfig properties are from the runtime dependent assets/config.json

--- a/apps/spa/src/main.ts
+++ b/apps/spa/src/main.ts
@@ -1,8 +1,19 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
+import { DynamicConfig } from './environments/dynamic-config.model';
+import { environment } from './environments/environment';
 
-platformBrowserDynamic()
-	.bootstrapModule(AppModule)
-	// eslint-disable-next-line no-console
-	.catch((err) => console.error(err));
+fetch('./assets/config.json')
+	.then((response) => response.json())
+	.then((config: unknown) => {
+		Object.assign(environment, {
+			...(config as DynamicConfig),
+			...environment,
+		});
+
+		platformBrowserDynamic()
+			.bootstrapModule(AppModule)
+			// eslint-disable-next-line no-console
+			.catch((err) => console.error(err));
+	});


### PR DESCRIPTION
# Description

Fixes an issue, where the environment was not changed in the app module by overwriting the environment in the main.ts before bootstrapping the application.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
