### PR TITLE
fix: get container logs on console in e2es

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: ./tools/db/kordis-db.sh init e2edb
       - name: Start API and SPA containers
         run: |
-          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://host.docker.internal:27017/e2edb kordis-api:${{ github.sha }}
+          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://host.docker.internal:27017/e2edb -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
           docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Start API and SPA containers
         run: |
           docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://172.17.0.1:27017/e2edb -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
-          docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
+          docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests
         run: npx wait-on -t 90s http://localhost:3000/health-check && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,12 @@ jobs:
       - name: Print Container Logs
         if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
         run: |
+          echo "::group::Kordis API Container Logs"
           docker logs kordis-api-container
+          echo "::endgroup::"
+          echo "::group::Kordis SPA Container Logs"
           docker logs kordis-spa-container
+          echo "::endgroup::"
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,10 @@ jobs:
         run: ./tools/db/kordis-db.sh init e2edb
       - name: Start API and SPA containers
         run: |
-          docker run -d -p 3000:3333 -e MONGODB_URI=mongodb://host.docker.internal:27017/e2edb kordis-api:${{ github.sha }}
-          docker run -d -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
+          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://host.docker.internal:27017/e2edb kordis-api:${{ github.sha }}
+          docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
       - name: Run E2Es
+        id: e2e-tests
         run: npx wait-on -t 30s tcp:3000 && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall
         env:
           E2E_BASE_URL: http://localhost:4200/
@@ -75,6 +76,11 @@ jobs:
           name: e2e-test-results
           path: test-results/
           if-no-files-found: ignore
+      - name: Print Container Logs
+        if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
+        run: |
+          docker logs kordis-api-container
+          docker logs kordis-spa-container
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests
-        run: npx wait-on -t 30s http://localhost:3000/health-check && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall
+        run: npx wait-on -t 90s http://localhost:3000/health-check && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall
         env:
           E2E_BASE_URL: http://localhost:4200/
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: ./tools/db/kordis-db.sh init e2edb
       - name: Start API and SPA containers
         run: |
-          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://host.docker.internal:27017/e2edb -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
+          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://172.17.0.1:27017/e2edb -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
           docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 -e AUTH_PROVIDER=dev kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests
-        run: npx wait-on -t 30s tcp:3000 && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall
+        run: npx wait-on -t 30s http://localhost:3000/health-check && npx wait-on -t 30s http://localhost:4200 && npx nx e2e spa-e2e --skipInstall
         env:
           E2E_BASE_URL: http://localhost:4200/
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

Provide the container logs to the console for failed e2e tests.

See [this GH Action run](https://github.com/kordis-leitstelle/kordis/actions/runs/8000326648/job/21849566332?pr=685#step:20:1) for the output of a failed run.



# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
