### PR TITLE
fix(spa): environment not loaded in app module

### DIFF
--- a/apps/spa/src/index.html
+++ b/apps/spa/src/index.html
@@ -23,6 +23,40 @@
 	</head>
 	<body>
 		<noscript>Bitte aktivieren Sie JavaScript um Kordis zu nutzen.</noscript>
-		<kordis-root ngCspNonce="csp_nonce"></kordis-root>
+		<kordis-root ngCspNonce="csp_nonce">
+			<style>
+				.loader-container {
+					display: flex;
+					justify-content: center;
+					align-items: center;
+					position: fixed;
+					width: 100%;
+					height: 100vh;
+				}
+
+				.loader {
+					width: 72px;
+					height: 72px;
+					border: 8px solid #1890ff;
+					border-bottom-color: transparent;
+					border-radius: 50%;
+					box-sizing: border-box;
+					animation: rotation 1s linear infinite;
+				}
+
+				@keyframes rotation {
+					0% {
+						transform: rotate(0deg);
+					}
+					100% {
+						transform: rotate(360deg);
+					}
+				}
+			</style>
+
+			<div class="loader-container">
+				<span class="loader"></span>
+			</div>
+		</kordis-root>
 	</body>
 </html>

--- a/apps/spa/src/main.ts
+++ b/apps/spa/src/main.ts
@@ -1,6 +1,5 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import { AppModule } from './app/app.module';
 import { DynamicConfig } from './environments/dynamic-config.model';
 import { environment } from './environments/environment';
 
@@ -11,9 +10,9 @@ fetch('./assets/config.json')
 			...(config as DynamicConfig),
 			...environment,
 		});
-
-		platformBrowserDynamic()
-			.bootstrapModule(AppModule)
-			// eslint-disable-next-line no-console
-			.catch((err) => console.error(err));
-	});
+	})
+	// we have to dynamically import the module, so the environment does not get evaluated before the fetch
+	.then(() => import('./app/app.module'))
+	.then(({ AppModule }) => platformBrowserDynamic().bootstrapModule(AppModule))
+	// eslint-disable-next-line no-console
+	.catch((err) => console.error(err));


### PR DESCRIPTION
# Description

Since we import the App Module before assigning the environment, the values from the config.json are not applied in time. This PR imports the App Module dynamically and adds a simple loading indicator.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
