### PR TITLE
ci: use chore for every renovate change to reduce release noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["config:base", ":semanticCommits"],
+	"extends": ["config:base", ":semanticCommitTypeAll(chore)"],
 	"schedule": ["after 8pm every weekday", "before 7pm on Sunday"],
 	"packageRules": [
 		{


### PR DESCRIPTION
Renovate pushes dependencies updates that are listed as prod dependencies as a fix. This leads to a new release every time a prod dependency is updated. This PR sets the Semantic Commit type to chore for every Renovate change.