### PR TITLE
chore(spa): make csp headers optional in docker image

### DIFF
--- a/apps/spa/docker/README.md
+++ b/apps/spa/docker/README.md
@@ -1,0 +1,52 @@
+# Nginx Configuration
+
+The current [nginx.conf](./nginx.conf) is a basic configuration file, that acts
+as a simple reverse proxy for the SPA. You can customize it to your needs and
+plug it in e.g. via k8s volumes.
+
+## CSP
+
+If you want to enforce Trusted Types and CSP, you can use the following
+configurations in your nginx.conf file:
+
+```
+	# change nonce in the apps index.html
+	sub_filter_once off;
+	sub_filter csp_nonce $request_id;
+
+	# add CSP and further security headers
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'nonce-$request_id'; object-src 'none'; base-uri 'self'; connect-src 'self'; img-src 'self'; style-src 'self' 'nonce-$request_id'; font-src 'self'; frame-ancestors 'self'; trusted-types angular angular#bundler dompurify default; require-trusted-types-for 'script';" always;
+	add_header Content-Type-Options "nosniff" always;
+	add_header X-Frame-Options "SAMEORIGIN" always;
+	add_header X-XSS-Protection "1; mode=block" always;
+	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+```
+
+If you the Sentry Observability adapter and B2C for auth and user management,
+add the following values to `connect-src`: `*.ingest.sentry.io *.b2clogin.com` +
+your API domain and also for Sentry `worker-src 'self' blob:;`
+
+## Compression
+
+For compression, you can use the following configurations in your nginx.conf
+file:
+
+```
+	gzip on;
+	gzip_comp_level 5;
+	gzip_min_length 1100;
+	gzip_buffers 4 32k;
+	gzip_proxied any;
+	gzip_types
+		application/javascript
+		application/json
+		application/x-javascript
+		application/xml
+		image/svg+xml
+		text/css
+		text/javascript
+		text/js
+		text/plain
+		text/xml;
+	gzip_vary on;
+```

--- a/apps/spa/docker/nginx.conf
+++ b/apps/spa/docker/nginx.conf
@@ -7,36 +7,6 @@ server {
 	index index.html;
 	root /usr/share/nginx/html;
 
-	# change nonce in the apps index.html
-	sub_filter_once off;
-	sub_filter csp_nonce $request_id;
-
-	# add CSP and further security headers
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'nonce-$request_id'; object-src 'none'; base-uri 'self'; connect-src 'self'; img-src 'self'; style-src 'self' 'nonce-$request_id'; font-src 'self'; frame-ancestors 'self'; trusted-types angular angular#bundler dompurify default; require-trusted-types-for 'script';" always;
-	add_header Content-Type-Options "nosniff" always;
-	add_header X-Frame-Options "SAMEORIGIN" always;
-	add_header X-XSS-Protection "1; mode=block" always;
-	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-	# enable gzip compression
-	gzip on;
-	gzip_comp_level 5;
-	gzip_min_length 1100;
-	gzip_buffers 4 32k;
-	gzip_proxied any;
-	gzip_types
-		application/javascript
-		application/json
-		application/x-javascript
-		application/xml
-		image/svg+xml
-		text/css
-		text/javascript
-		text/js
-		text/plain
-		text/xml;
-	gzip_vary on;
-
 	location / {
 			real_ip_header X-Forwarded-For;
 			set_real_ip_from 10.0.0.0/8;


### PR DESCRIPTION
# Description

Currently, the CSP configurations are hard-coded into the nginx config of the spa docker image, which also consists of the reverse proxy. As we need to add some sources, such as sentry, aadb2c and so on, which are specific to our instance, it would be a better approach to loosen the configuration to the minimum and offer an approach where the config can be adjusted to the instance's needs. Thus, this PR removes the CSP and compression config. A dedicated PR will cover the necessary changes of the infrastructure in our infra repo.
