### PR TITLE
fix(api-observability): sentry exception filter logger not provided correctly

### DIFF
--- a/libs/api/observability/src/lib/filters/sentry-exceptions.filter.spec.ts
+++ b/libs/api/observability/src/lib/filters/sentry-exceptions.filter.spec.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import * as Sentry from '@sentry/node';
 
 import { PresentableException } from '@kordis/api/shared';
@@ -11,15 +12,22 @@ describe('SentryExceptionsFilter', () => {
 	let addBreadcrumbMock: jest.Mock;
 	let captureExceptionMock: jest.Mock;
 	let logger: DeepMocked<Logger>;
+
 	beforeEach(async () => {
 		addBreadcrumbMock = jest.fn();
 		captureExceptionMock = jest.fn();
-		logger = createMock<Logger>();
-
 		(Sentry.addBreadcrumb as jest.Mock) = addBreadcrumbMock;
 		(Sentry.captureException as jest.Mock) = captureExceptionMock;
+		logger = createMock<Logger>();
 
-		sentryExceptionsFilter = new SentryExceptionsFilter(logger);
+		const moduleRef = await Test.createTestingModule({
+			providers: [SentryExceptionsFilter],
+		}).compile();
+
+		moduleRef.useLogger(logger);
+		sentryExceptionsFilter = moduleRef.get<SentryExceptionsFilter>(
+			SentryExceptionsFilter,
+		);
 	});
 
 	afterEach(() => {

--- a/libs/api/observability/src/lib/filters/sentry-exceptions.filter.ts
+++ b/libs/api/observability/src/lib/filters/sentry-exceptions.filter.ts
@@ -7,11 +7,7 @@ import { KordisLogger } from '../services/kordis-logger.interface';
 
 @Catch()
 export class SentryExceptionsFilter implements ExceptionFilter {
-	readonly logger: KordisLogger;
-
-	constructor(_logger: Logger) {
-		this.logger = _logger;
-	}
+	private readonly logger: KordisLogger = new Logger();
 
 	catch(exception: unknown): void {
 		if (exception instanceof PresentableException) {

--- a/libs/api/observability/src/lib/sentry-observability.module.ts
+++ b/libs/api/observability/src/lib/sentry-observability.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module, OnModuleInit } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APP_FILTER, APP_INTERCEPTOR, ModulesContainer } from '@nestjs/core';
 import { init as initSentry } from '@sentry/node';
@@ -7,7 +7,6 @@ import { SentryExceptionsFilter } from './filters/sentry-exceptions.filter';
 import { SentryOTelUserContextInterceptor } from './interceptors/sentry-otel-user-context.interceptor';
 import oTelSDK from './oTelSdk';
 import { KORDIS_LOGGER_SERVICE } from './services/kordis-logger-service.interface';
-import { KordisLogger } from './services/kordis-logger.interface';
 import { SentryLogger } from './services/sentry-logger.service';
 import { wrapProvidersWithTracingSpans } from './trace-wrapper';
 
@@ -30,10 +29,6 @@ import { wrapProvidersWithTracingSpans } from './trace-wrapper';
 	exports: [KORDIS_LOGGER_SERVICE],
 })
 export class SentryObservabilityModule implements OnModuleInit {
-	private readonly logger: KordisLogger = new Logger(
-		SentryObservabilityModule.name,
-	);
-
 	constructor(
 		private readonly config: ConfigService,
 		private readonly modulesContainer: ModulesContainer,
@@ -49,7 +44,5 @@ export class SentryObservabilityModule implements OnModuleInit {
 		});
 		wrapProvidersWithTracingSpans(this.modulesContainer);
 		oTelSDK.start();
-
-		this.logger.log('Sentry initialized');
 	}
 }


### PR DESCRIPTION
This was the reason for the containers not to start. The logger was not available in the exception filter, since it gets provided later on.