### PR TITLE
refactor(api): use native ID and DateTime scalar types

### DIFF
--- a/libs/api/shared/src/lib/models/base-entity.model.ts
+++ b/libs/api/shared/src/lib/models/base-entity.model.ts
@@ -1,5 +1,5 @@
 import { AutoMap } from '@automapper/classes';
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, ID, ObjectType } from '@nestjs/graphql';
 import { validate } from 'class-validator';
 
 import { ValidationException } from '../exceptions';
@@ -12,12 +12,12 @@ export interface BaseModel {
 
 @ObjectType()
 export abstract class BaseEntityModel implements BaseModel {
-	@Field()
+	@Field(() => ID)
 	readonly id: string;
-	@Field(() => String)
+	@Field()
 	@AutoMap()
 	readonly createdAt: Date = new Date();
-	@Field(() => String)
+	@Field()
 	@AutoMap()
 	readonly updatedAt: Date;
 

--- a/libs/api/user/src/lib/core/entity/user.entity.ts
+++ b/libs/api/user/src/lib/core/entity/user.entity.ts
@@ -1,10 +1,10 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, ID, ObjectType } from '@nestjs/graphql';
 
 import { Role } from '@kordis/shared/model';
 
 @ObjectType()
 export class UserEntity {
-	@Field()
+	@Field(() => ID)
 	id: string;
 
 	@Field()


### PR DESCRIPTION
# Description

As discussed, we want to use scalar types that match the fields best. 
- Use `ID` for identity fields as this is more declarative and is [relevant for caching (depending on the implementation)](https://www.apollographql.com/docs/apollo-server/schema/schema/#scalar-types)
- Use [the `GraphQLISODateTime` from NestJS](https://docs.nestjs.com/graphql/scalars) for `Date` objects to enable automatic deserialization on the client side and improved readability.

**Note**: Currently, custom scalar types are not supported by Apollo client. Based on [this comment](https://github.com/apollographql/apollo-feature-requests/issues/368#issuecomment-1608460456) and [this](https://community.apollographql.com/t/custom-scalars-on-the-client-side/6587/3) they are planned for version 3.10 or 3.11. However, the [roadmap for 3.10](https://github.com/apollographql/apollo-client/blob/main/ROADMAP.md) states nothing about that and even the [early planning for version 4](https://github.com/apollographql/apollo-client/milestone/31) doesn't mention custom scalars. A [workaround](https://community.apollographql.com/t/custom-scalars-on-the-client-side/6587/3) might work involving [custom readers for some cache fields](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#the-read-function).

The feature request is tracked in ticket https://github.com/apollographql/apollo-feature-requests/issues/368

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).