### PR TITLE
chore: activate replicasets for transactions in dev db init script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,12 @@ jobs:
       - name: Install Chromium for E2Es
         run: npx -y playwright install chromium
       - name: Start and prepare MongoDB for E2Es
-        run: ./tools/db/kordis-db.sh init e2edb
+        run: |
+          export MONGO_HOST=172.17.0.1
+          ./tools/db/kordis-db.sh init e2edb
       - name: Start API and SPA containers
         run: |
-          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://172.17.0.1:27017/e2edb -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
+          docker run -d --name kordis-api-container -p 3000:3333 -e MONGODB_URI=mongodb://172.17.0.1:27017/e2edb?replicaSet=rs0 -e AUTH_PROVIDER=dev kordis-api:${{ github.sha }}
           docker run -d --name kordis-spa-container -p 4200:8080 -e API_URL=http://localhost:3000 kordis-spa:${{ github.sha }}
       - name: Run E2Es
         id: e2e-tests

--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -9,7 +9,8 @@ running on your maschine.
 The data for the test database is within the [`data`](./data/) folder. If you
 want to create a new collection, use the [`template.ts`](./data/template.ts) as
 a starter for your file. The naming of the file should be
-`<collection name>.data.ts`.  
+`<collection name>.data.ts`. To generate an MongoDB ObjectId, you can use
+[this online tool](https://observablehq.com/@hugodf/mongodb-objectid-generator).
 Please adjust the test data in your branch if you introduce migrations!
 
 ### Start


### PR DESCRIPTION
As we also need to activate replicasets in our local development DB as we did on remote, we need to change the database script a bit. Before running init, please remove the existing mongodb container!