### PR TITLE
chore(api): add unit of work service for transactions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,13 +6,19 @@
 	"proseWrap": "always",
 	"overrides": [
 		{
-			"files": ["*.ts"],
+			"files": [
+				"*.ts"
+			],
 			"options": {
 				"parser": "typescript",
-				"importOrder": ["^@kordis/(.*)$", "^[./]"],
+				"importOrder": [
+					"^@kordis/(.*)$",
+					"^[./]"
+				],
 				"importOrderSeparation": true,
 				"importOrderSortSpecifiers": true,
 				"importOrderParserPlugins": [
+					"explicitResourceManagement",
 					"classProperties",
 					"decorators-legacy",
 					"typescript"
@@ -20,5 +26,7 @@
 			}
 		}
 	],
-	"plugins": ["@trivago/prettier-plugin-sort-imports"]
+	"plugins": [
+		"@trivago/prettier-plugin-sort-imports"
+	]
 }

--- a/libs/api/shared/src/index.ts
+++ b/libs/api/shared/src/index.ts
@@ -7,7 +7,7 @@ export * from './lib/kernel/shared-kernel.module';
 export * from './lib/exceptions';
 export {
 	UnitOfWorkService,
-	MongoUoWSessionProvider,
+	DbSessionProvider,
 	UNIT_OF_WORK_SERVICE,
 	UnitOfWork,
 	runDbOperation,

--- a/libs/api/shared/src/index.ts
+++ b/libs/api/shared/src/index.ts
@@ -5,3 +5,10 @@ export * from './lib/kernel/graphql';
 export * from './lib/kernel/mongodb';
 export * from './lib/kernel/shared-kernel.module';
 export * from './lib/exceptions';
+export {
+	UnitOfWorkService,
+	MongoUoWSessionProvider,
+	UNIT_OF_WORK_SERVICE,
+	UnitOfWork,
+	runDbOperation,
+} from './lib/kernel/service/unit-of-work.service';

--- a/libs/api/shared/src/lib/kernel/service/unit-of-work.service.spec.ts
+++ b/libs/api/shared/src/lib/kernel/service/unit-of-work.service.spec.ts
@@ -1,0 +1,106 @@
+import { createMock } from '@golevelup/ts-jest';
+import { getConnectionToken } from '@nestjs/mongoose';
+import { Test } from '@nestjs/testing';
+import { ClientSession, Connection } from 'mongoose';
+
+import { UnitOfWork, UnitOfWorkServiceImpl } from './unit-of-work.service';
+
+describe('UnitOfWorkServiceImpl', () => {
+	let service: UnitOfWorkServiceImpl;
+	let mockSession: ClientSession;
+	let mockConnection: Connection;
+
+	beforeEach(async () => {
+		mockSession = createMock<ClientSession>();
+		mockConnection = createMock<Connection>({
+			startSession: jest.fn().mockResolvedValue(mockSession),
+		});
+
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				UnitOfWorkServiceImpl,
+				{ provide: getConnectionToken('Database'), useValue: mockConnection },
+			],
+		}).compile();
+
+		service = moduleRef.get<UnitOfWorkServiceImpl>(UnitOfWorkServiceImpl);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should start a new unit of work', async () => {
+		const unitOfWork = await service.startUnitOfWork();
+
+		expect(unitOfWork.session).toBeDefined();
+	});
+
+	// todo: complete this test when https://github.com/jestjs/jest/issues/14874 has been released (v30)
+	// eslint-disable-next-line jest/no-commented-out-tests
+	/*
+	it('should start a new unit of work and end session on disposal', async () => {
+			await using unitOfWork = await service.startUnitOfWork();
+
+		expect(unitOfWork).toBeDefined();
+		expect(unitOfWork.session).toBe(mockSession);
+		expect(mockConnection.startSession).toHaveBeenCalled();
+		await unitOfWork[Symbol.asyncDispose]();
+		expect(unitOfWork).toBeUndefined();
+		expect(mockSession.endSession).toHaveBeenCalled();
+	});
+
+	it('should execute and commit work in a transaction', async () => {
+		const work = jest.fn().mockResolvedValue(undefined);
+
+		await service.asTransaction(work);
+		expect(work).toHaveBeenCalledWith(expect.any(UnitOfWork));
+	});
+
+	it('should execute work in a transaction', async () => {
+		const work = jest.fn().mockRejectedValueOnce(new Error('Oh no'));
+
+		await expect(service.asTransaction(work)).rejects.toThrow('Oh no');
+
+		expect(work).toHaveBeenCalledWith(expect.any(UnitOfWork));
+	});
+
+	it('should rollback failed work', async () => {
+		const work = jest.fn().mockResolvedValue(undefined);
+
+		await service.asTransaction(work);
+
+		expect(work).toHaveBeenCalledWith(expect.any(UnitOfWork));
+	});
+	 */
+});
+
+describe('UnitOfWork', () => {
+	let unitOfWork: UnitOfWork;
+	let mockSession: ClientSession;
+
+	beforeEach(() => {
+		mockSession = {
+			commitTransaction: jest.fn(),
+			abortTransaction: jest.fn(),
+			endSession: jest.fn(),
+		} as unknown as ClientSession;
+
+		unitOfWork = new UnitOfWork(mockSession);
+	});
+
+	it('should commit', async () => {
+		await unitOfWork.commit();
+		expect(mockSession.commitTransaction).toHaveBeenCalled();
+	});
+
+	it('should rollback', async () => {
+		await unitOfWork.rollback();
+		expect(mockSession.abortTransaction).toHaveBeenCalled();
+	});
+
+	it('should end session', async () => {
+		await unitOfWork[Symbol.asyncDispose]();
+		expect(mockSession.endSession).toHaveBeenCalled();
+	});
+});

--- a/libs/api/shared/src/lib/kernel/service/unit-of-work.service.ts
+++ b/libs/api/shared/src/lib/kernel/service/unit-of-work.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { InjectConnection } from '@nestjs/mongoose';
+import { ClientSession, Connection, SessionOperation } from 'mongoose';
+
+export interface MongoUoWSessionProvider {
+	session: ClientSession;
+}
+
+export const UNIT_OF_WORK_SERVICE = Symbol('UNIT_OF_WORK_SERVICE');
+
+export class UnitOfWork implements MongoUoWSessionProvider, AsyncDisposable {
+	constructor(readonly session: ClientSession) {}
+
+	async commit(): Promise<void> {
+		await this.session.commitTransaction();
+	}
+
+	async rollback(): Promise<void> {
+		await this.session.abortTransaction();
+	}
+
+	async [Symbol.asyncDispose](): Promise<void> {
+		await this.session.endSession();
+	}
+}
+
+export interface UnitOfWorkService {
+	startUnitOfWork(): Promise<UnitOfWork>;
+
+	asTransaction(
+		work: (uow: UnitOfWork) => Promise<void>,
+		retries?: number,
+	): Promise<void>;
+}
+
+@Injectable()
+export class UnitOfWorkServiceImpl implements UnitOfWorkService {
+	constructor(@InjectConnection() private readonly connection: Connection) {}
+
+	async startUnitOfWork(): Promise<UnitOfWork> {
+		const session = await this.connection.startSession();
+
+		return new UnitOfWork(session);
+	}
+
+	/**
+	 * Executes the provided work and attempts to commit it. If it fails, it will rollback and retry the work up to the specified number of times.
+	 * @param work The work to be done in the transaction, usually a series of repository operations. Receives an instance of UnitOfWork with current active DB session to provide to repositories.
+	 * @param retries Number of retries to attempt if the transaction fails (error is thrown)
+	 */
+	async asTransaction(
+		work: (uow: UnitOfWork) => Promise<void>,
+		retries = 0,
+	): Promise<void> {
+		await using uow = await this.startUnitOfWork();
+
+		let tries = 0;
+		do {
+			uow.session.startTransaction();
+			try {
+				await work(uow);
+
+				await uow.commit();
+
+				break;
+			} catch (e) {
+				await uow.rollback();
+				if (tries++ >= retries) {
+					throw e;
+				}
+			}
+		} while (tries !== 0 && tries < retries);
+	}
+}
+
+export function runDbOperation<T = void>(
+	op: SessionOperation & { exec: () => Promise<T> },
+	uow?: UnitOfWork,
+): Promise<T> {
+	if (uow) {
+		op.session(uow.session);
+	}
+
+	return op.exec();
+}

--- a/libs/api/shared/src/lib/kernel/shared-kernel.module.ts
+++ b/libs/api/shared/src/lib/kernel/shared-kernel.module.ts
@@ -4,6 +4,10 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { GraphQLSubscriptionService } from './graphql';
 import { MongoEncryptionClientProvider } from './mongodb';
 import { MongoEncryptionService } from './mongodb/mongo-encryption.service';
+import {
+	UNIT_OF_WORK_SERVICE,
+	UnitOfWorkServiceImpl,
+} from './service/unit-of-work.service';
 
 @Global()
 @Module({
@@ -12,12 +16,14 @@ import { MongoEncryptionService } from './mongodb/mongo-encryption.service';
 		GraphQLSubscriptionService,
 		MongoEncryptionClientProvider,
 		MongoEncryptionService,
+		{ provide: UNIT_OF_WORK_SERVICE, useClass: UnitOfWorkServiceImpl },
 	],
 	exports: [
 		GraphQLSubscriptionService,
 		MongoEncryptionClientProvider,
 		MongoEncryptionService,
 		CqrsModule,
+		UNIT_OF_WORK_SERVICE,
 	],
 })
 export class SharedKernel {}


### PR DESCRIPTION
# Description

To run transactions, this PR introduces a unit of work service, that starts a [MongoDB transaction](https://www.mongodb.com/docs/manual/core/transactions/#transactions-api) and automatically closes the session on disposal with the new r[esource management pattern](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management). Consequently, we also need to add the parser plugin to prettier. 

You can use it as following: call `startunitOfWork()` and manage the committing and the rollbacks yourself, or as a more convenient way call asTransactions and just pass a lambda/function that includes some repository calls.

How one should implement
 ```
async updateSomething(
		id: string,
		payload: SomeDTO,
		uow?: UnitOfWork | undefined,
	): Promise<void> {
const query = this.model.updateOne(....) <-- no await!
await runDbOperation(query, uow) <-- will handle the case that the uow is undefined, if not it will set the session and execute the operation. 
}
```

Currently, Jest does not support the Disposable symbol (https://github.com/jestjs/jest/issues/14874), hence we cannot test this probably right now. It is subject to release in v30. I added this to the tech debt list.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).

<!-- Uncomment the following lines if you introduced a new API library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json` 
-->
<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
