### PR TITLE
chore: create gql schema in api folder for discovery

### DIFF
--- a/apps/api/src/generate-schema.ts
+++ b/apps/api/src/generate-schema.ts
@@ -11,7 +11,7 @@ const generateSchema = async (): Promise<void> => {
 	await app.init();
 
 	const { schema } = app.get(GraphQLSchemaHost);
-	const outputPath = join(process.cwd(), 'dist/schema.gql');
+	const outputPath = join(process.cwd(), 'apps/api/src/schema.gql');
 	writeFileSync(outputPath, printSchema(schema));
 	await app.close();
 	// eslint-disable-next-line no-console

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'dist/schema.gql'
+schema: 'apps/api/src/schema.gql'
 generates:
   libs/shared/model/src/lib/gql.model.ts:
     plugins:


### PR DESCRIPTION
Currently, the schema will be built in the dist/ folder, resulting in no discovery by the Webstorm GraphQL plugin due to the dist folder being ignored (probably the same for vs code). Now, the schema will be generated into the api folder.