### PR TITLE
chore(api): add config to serve api for debugging

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -23,6 +23,10 @@
 					"extractLicenses": true,
 					"generatePackageJson": true,
 					"inspect": false
+				},
+				"debug": {
+					"inspect": true,
+					"sourceMap": true
 				}
 			}
 		},
@@ -34,6 +38,9 @@
 			"configurations": {
 				"production": {
 					"buildTarget": "api:build:production"
+				},
+				"debug": {
+					"buildTarget": "api:build:debug"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "ng": "nx",
     "serve:api": "nx serve api",
+    "serve:api:debug": "nx serve api -c debug",
     "serve:spa": "nx serve spa",
     "postinstall": "node ./decorate-angular-cli.js",
     "prepare": "husky install",


### PR DESCRIPTION
Now, you can debug the API with `npm run serve:api:debug`. In webstorm, one can start the npm script with the in-build debugger, idk how it works in vscode