### PR TITLE
fix(api-shared): graphql subscription service not returning correct structure

### DIFF
--- a/libs/api/user/src/lib/infra/controller/user.resolver.spec.ts
+++ b/libs/api/user/src/lib/infra/controller/user.resolver.spec.ts
@@ -313,7 +313,7 @@ describe('UserResolver', () => {
 
 			await expect(subscriptionIterable.next()).resolves.toEqual(
 				expect.objectContaining({
-					value: { userId: 'userid' },
+					value: { currentUserDeactivated: { userId: 'userid' } },
 				}),
 			);
 		});

--- a/libs/api/user/src/lib/infra/controller/user.resolver.ts
+++ b/libs/api/user/src/lib/infra/controller/user.resolver.ts
@@ -152,14 +152,13 @@ export class UserResolver {
 		return true;
 	}
 
-	@Subscription(() => UserDeactivated, {
-		resolve: (payload) => payload,
-	})
+	@Subscription(() => UserDeactivated)
 	currentUserDeactivated(
 		@RequestUser() { id }: AuthUser,
 	): AsyncIterableIterator<UserDeactivated> {
 		return this.graphqlSubscriptions.getSubscriptionIteratorForEvent(
 			UserDeactivatedEvent,
+			'currentUserDeactivated',
 			{
 				filter: ({ userId }: UserDeactivatedEvent) => userId === id,
 			},


### PR DESCRIPTION
Currently, the mapping required a resolve function in subscription handlers. By moving this to the subscription service we fix this behavior. No we have to pass the name of the graphql subscription field, and the service will map it automatically. 