### PR TITLE
feat(api): introduce units and alert groups

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -19,9 +19,9 @@ import {
 	getMongoEncrKmsFromConfig,
 } from '@kordis/api/shared';
 import { TetraModule } from '@kordis/api/tetra';
+import { UnitModule, UnitsSagaModule } from '@kordis/api/unit';
 import { UsersModule } from '@kordis/api/user';
 
-import { AppResolver } from './app.resolver';
 import { AppService } from './app.service';
 import { GraphqlSubscriptionsController } from './controllers/graphql-subscriptions.controller';
 import { HealthCheckController } from './controllers/health-check.controller';
@@ -33,8 +33,9 @@ const isNextOrProdEnv = ['next', 'prod'].includes(
 
 const FEATURE_MODULES = [
 	OrganizationModule,
-	TetraModule,
 	UsersModule.forRoot(process.env.AUTH_PROVIDER === 'dev' ? 'dev' : 'aadb2c'),
+	UnitModule,
+	TetraModule,
 ];
 const UTILITY_MODULES = [
 	SharedKernel,
@@ -92,6 +93,7 @@ const UTILITY_MODULES = [
 						...kms,
 						bypassAutoEncryption: true,
 					},
+					ignoreUndefined: true,
 				};
 			},
 			inject: [ConfigService, MongoEncryptionClientProvider],

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -37,6 +37,7 @@ const FEATURE_MODULES = [
 	UnitModule,
 	TetraModule,
 ];
+const SAGA_MODULES = [UnitsSagaModule];
 const UTILITY_MODULES = [
 	SharedKernel,
 	ObservabilityModule.forRoot(isNextOrProdEnv ? 'sentry' : 'dev'),
@@ -103,8 +104,9 @@ const UTILITY_MODULES = [
 		}),
 		...UTILITY_MODULES,
 		...FEATURE_MODULES,
+		...SAGA_MODULES,
 	],
-	providers: [AppService, AppResolver],
+	providers: [AppService],
 	controllers: [GraphqlSubscriptionsController, HealthCheckController],
 })
 export class AppModule {}

--- a/libs/api/shared/src/index.ts
+++ b/libs/api/shared/src/index.ts
@@ -14,3 +14,4 @@ export {
 	UnitOfWork,
 	runDbOperation,
 } from './lib/kernel/service/unit-of-work.service';
+export { BaseModelProfile } from './lib/models/base-model.mapper-profile';

--- a/libs/api/shared/src/lib/models/base-entity.model.ts
+++ b/libs/api/shared/src/lib/models/base-entity.model.ts
@@ -13,6 +13,7 @@ export interface BaseModel {
 @ObjectType({ isAbstract: true })
 export class BaseEntityModel extends Validatable implements BaseModel {
 	@Field(() => ID)
+	@AutoMap()
 	readonly id: string;
 	@IsString()
 	@IsNotEmpty()
@@ -22,7 +23,7 @@ export class BaseEntityModel extends Validatable implements BaseModel {
 	@Field()
 	@AutoMap()
 	readonly createdAt: Date = new Date();
-	@Field()
+	@Field({ nullable: true })
 	@AutoMap()
 	readonly updatedAt: Date;
 }

--- a/libs/api/test-helpers/src/lib/mongo.test-helper.ts
+++ b/libs/api/test-helpers/src/lib/mongo.test-helper.ts
@@ -1,17 +1,39 @@
-import { Model } from 'mongoose';
+import { createMock } from '@golevelup/ts-jest';
+import { ClientSession, Model } from 'mongoose';
+
+import {
+	DbSessionProvider,
+	UNIT_OF_WORK_SERVICE,
+	UnitOfWorkService,
+} from '@kordis/api/shared';
+
+// we need to mock the uow service until jest v30 (https://github.com/jestjs/jest/issues/14874)
+export function uowMockProvider() {
+	return {
+		provide: UNIT_OF_WORK_SERVICE,
+		useValue: createMock<UnitOfWorkService>({
+			asTransaction(
+				work: (uow: DbSessionProvider) => Promise<void>,
+			): Promise<void> {
+				return work({ session: createMock<ClientSession>() });
+			},
+		}),
+	};
+}
 
 export function mockModelMethodResult(
 	model: Model<any>,
 	document: Record<string, any> | null,
-	method: keyof Model<unknown>,
+	method: 'findById' | 'findOne' | 'findOneAndUpdate',
 ) {
-	const findByIdSpy = jest.spyOn(model, method as any);
+	const spy = jest.spyOn(model, method as any);
 
-	findByIdSpy.mockReturnThis().mockReturnValue({
+	spy.mockReturnThis().mockReturnValue({
 		exec: jest.fn().mockReturnValue({
 			...document,
 			toObject: jest.fn().mockReturnValue(document),
 		}),
+		populate: jest.fn().mockReturnThis(),
 		lean: jest.fn().mockReturnValue({
 			...document,
 			toObject: jest.fn().mockReturnValue(document),
@@ -19,5 +41,23 @@ export function mockModelMethodResult(
 		}),
 	} as any);
 
-	return findByIdSpy;
+	return spy;
+}
+
+export function mockModelMethodResults(
+	model: Model<any>,
+	documents: Record<string, any>[],
+	method: 'find' | 'aggregate',
+) {
+	const spy = jest.spyOn(model, method);
+
+	spy.mockReturnThis().mockReturnValue({
+		lean: jest.fn().mockReturnValue({
+			exec: jest.fn().mockReturnValue(documents),
+		}),
+		populate: jest.fn().mockReturnThis(),
+		exec: jest.fn().mockReturnValue(documents),
+	} as any);
+
+	return spy;
 }

--- a/libs/api/tetra/src/lib/core/command/handle-tetra-control-webhook.command.spec.ts
+++ b/libs/api/tetra/src/lib/core/command/handle-tetra-control-webhook.command.spec.ts
@@ -70,7 +70,7 @@ describe('HandleTetraControlWebhookHandler', () => {
 		});
 
 		expect(eventBus.publish).toHaveBeenCalledWith(
-			new NewTetraStatusEvent('orgId', 'sender', 1, date, 'tetracontrol'),
+			new NewTetraStatusEvent('orgId', 'sender', 1, date, 'TetraControl'),
 		);
 	});
 
@@ -89,7 +89,7 @@ describe('HandleTetraControlWebhookHandler', () => {
 		});
 
 		expect(eventBus.publish).toHaveBeenCalledWith(
-			new NewTetraStatusEvent('orgId', 'sender', 1, date, 'tetracontrol'),
+			new NewTetraStatusEvent('orgId', 'sender', 1, date, 'TetraControl'),
 		);
 	});
 });

--- a/libs/api/tetra/src/lib/core/command/handle-tetra-control-webhook.command.ts
+++ b/libs/api/tetra/src/lib/core/command/handle-tetra-control-webhook.command.ts
@@ -47,7 +47,7 @@ export class HandleTetraControlWebhookHandler
 						payload.sender,
 						parseInt(payload.data.status),
 						this.getSanitizedTimestamp(payload.timestamp),
-						'tetracontrol',
+						'TetraControl',
 					),
 				);
 				break;

--- a/libs/api/unit/.eslintrc.json
+++ b/libs/api/unit/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/libs/api/unit/README.md
+++ b/libs/api/unit/README.md
@@ -1,0 +1,10 @@
+# API Unit
+
+This library is responsable for units and alert groups. It mainly acts as the
+primary data holder for the unit and alert group master data. Furthermore, it
+includes a Saga, which converts the `NewTetraStatusEvent` from the Tetra Domain
+into a `UpdateUnitStatusCommand`to update the status of a unit.
+
+## Running unit tests
+
+Run `nx test api-unit` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/api/unit/jest.config.ts
+++ b/libs/api/unit/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+	displayName: 'api-unit',
+	preset: '../../../jest.preset.js',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+	},
+	moduleFileExtensions: ['ts', 'js', 'html'],
+	coverageDirectory: '../../../coverage/libs/api/unit',
+};

--- a/libs/api/unit/project.json
+++ b/libs/api/unit/project.json
@@ -1,0 +1,30 @@
+{
+	"name": "api-unit",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "libs/api/unit/src",
+	"projectType": "library",
+	"targets": {
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["libs/api/unit/**/*.ts"]
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/api/unit/jest.config.ts",
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		}
+	},
+	"tags": []
+}

--- a/libs/api/unit/src/index.ts
+++ b/libs/api/unit/src/index.ts
@@ -1,0 +1,6 @@
+export * from './lib/infra/unit.module';
+export * from './lib/sagas/units-sagas.module';
+export * from './lib/infra/unit.view-model';
+export * from './lib/infra/alert-group.view-model';
+export { GetUnitsByIdsQuery } from './lib/core/query/get-units-by-ids.query';
+export { GetAlertGroupsByIdsQuery } from './lib/core/query/get-alert-groups-by-ids.query';

--- a/libs/api/unit/src/lib/core/command/update-unit-note.command.spec.ts
+++ b/libs/api/unit/src/lib/core/command/update-unit-note.command.spec.ts
@@ -1,0 +1,40 @@
+import { Test } from '@nestjs/testing';
+
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import {
+	UpdateUnitNoteCommand,
+	UpdateUnitNoteHandler,
+} from './update-unit-note.command';
+
+describe('UpdateUnitNoteHandler', () => {
+	let handler: UpdateUnitNoteHandler;
+	let repository: UnitRepository;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				UpdateUnitNoteHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						updateNote: jest.fn().mockResolvedValue(true),
+					},
+				},
+			],
+		}).compile();
+
+		handler = moduleRef.get<UpdateUnitNoteHandler>(UpdateUnitNoteHandler);
+		repository = moduleRef.get<UnitRepository>(UNIT_REPOSITORY);
+	});
+
+	it('should call repository.updateNote() when handler.execute() is called', async () => {
+		const command = new UpdateUnitNoteCommand('orgId', 'unitId', 'note');
+		await handler.execute(command);
+
+		expect(repository.updateNote).toHaveBeenCalledWith(
+			'orgId',
+			'unitId',
+			'note',
+		);
+	});
+});

--- a/libs/api/unit/src/lib/core/command/update-unit-note.command.ts
+++ b/libs/api/unit/src/lib/core/command/update-unit-note.command.ts
@@ -1,0 +1,30 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class UpdateUnitNoteCommand {
+	constructor(
+		readonly orgId: string,
+		readonly unitId: string,
+		readonly note: string,
+	) {}
+}
+
+@CommandHandler(UpdateUnitNoteCommand)
+export class UpdateUnitNoteHandler
+	implements ICommandHandler<UpdateUnitNoteCommand, boolean>
+{
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+	) {}
+
+	async execute({
+		unitId,
+		note,
+		orgId,
+	}: UpdateUnitNoteCommand): Promise<boolean> {
+		return this.repository.updateNote(orgId, unitId, note);
+	}
+}

--- a/libs/api/unit/src/lib/core/command/update-unit-status.command.spec.ts
+++ b/libs/api/unit/src/lib/core/command/update-unit-status.command.spec.ts
@@ -1,0 +1,108 @@
+import { CqrsModule, EventBus } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+
+import { ValidationException } from '@kordis/api/shared';
+
+import { UnitStatusUpdatedEvent } from '../event/unit-status-updated.event';
+import { UnitStatusOutdatedException } from '../exception/unit-status-outdated.exception';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import {
+	UpdateUnitStatusCommand,
+	UpdateUnitStatusHandler,
+} from './update-unit-status.command';
+
+describe('UpdateUnitStatusHandler', () => {
+	let handler: UpdateUnitStatusHandler;
+	let repository: UnitRepository;
+	let eventBus: EventBus;
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [CqrsModule],
+			providers: [
+				UpdateUnitStatusHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						updateStatus: jest.fn().mockResolvedValue(true),
+					},
+				},
+			],
+		}).compile();
+
+		handler = moduleRef.get<UpdateUnitStatusHandler>(UpdateUnitStatusHandler);
+		repository = moduleRef.get<UnitRepository>(UNIT_REPOSITORY);
+		eventBus = moduleRef.get<EventBus>(EventBus);
+	});
+
+	it('should throw an error when an incorrect status is passed', async () => {
+		const command = new UpdateUnitStatusCommand(
+			'orgId',
+			'unitId',
+			-1,
+			new Date(),
+			'source',
+		);
+		await expect(handler.execute(command)).rejects.toThrow(ValidationException);
+	});
+
+	it('should update status', async () => {
+		const command = new UpdateUnitStatusCommand(
+			'orgId',
+			'unitId',
+			1,
+			new Date(),
+			'source',
+		);
+		await handler.execute(command);
+
+		expect(repository.updateStatus).toHaveBeenCalledWith(
+			'orgId',
+			'unitId',
+			expect.anything(),
+		);
+	});
+
+	it('should not update the status if the status is outdated', async () => {
+		jest.spyOn(repository, 'updateStatus').mockResolvedValueOnce(false);
+
+		const command = new UpdateUnitStatusCommand(
+			'orgId',
+			'unitId',
+			1,
+			new Date(),
+			'source',
+		);
+		await expect(handler.execute(command)).rejects.toThrow(
+			UnitStatusOutdatedException,
+		);
+	});
+
+	it('should emit event on status updated', async () => {
+		jest.spyOn(repository, 'updateStatus').mockResolvedValueOnce(true);
+		const sentAt = new Date();
+		const command = new UpdateUnitStatusCommand(
+			'orgId',
+			'unitId',
+			1,
+			sentAt,
+			'source',
+		);
+		return new Promise<void>((done) => {
+			eventBus.subscribe((event) => {
+				expect(event).toBeInstanceOf(UnitStatusUpdatedEvent);
+				expect(event).toEqual({
+					orgId: 'orgId',
+					unitId: 'unitId',
+					status: {
+						status: 1,
+						receivedAt: sentAt,
+						source: 'source',
+					},
+				});
+				done();
+			});
+
+			return handler.execute(command);
+		});
+	});
+});

--- a/libs/api/unit/src/lib/core/command/update-unit-status.command.ts
+++ b/libs/api/unit/src/lib/core/command/update-unit-status.command.ts
@@ -1,0 +1,67 @@
+import { Inject, Logger } from '@nestjs/common';
+import { CommandHandler, EventBus, ICommandHandler } from '@nestjs/cqrs';
+
+import { KordisLogger } from '@kordis/api/observability';
+
+import { PersistentUnitStatus } from '../entity/status.type';
+import { UnitStatus } from '../entity/unit.entity';
+import { UnitStatusUpdatedEvent } from '../event/unit-status-updated.event';
+import { UnitStatusOutdatedException } from '../exception/unit-status-outdated.exception';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class UpdateUnitStatusCommand {
+	constructor(
+		readonly orgId: string,
+		readonly unitId: string,
+		readonly status: PersistentUnitStatus,
+		readonly receivedAt: Date,
+		readonly source: string,
+	) {}
+}
+
+@CommandHandler(UpdateUnitStatusCommand)
+export class UpdateUnitStatusHandler
+	implements ICommandHandler<UpdateUnitStatusCommand, void>
+{
+	private readonly logger: KordisLogger = new Logger(
+		UpdateUnitStatusHandler.name,
+	);
+
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+		private readonly eventBus: EventBus,
+	) {}
+
+	async execute({
+		orgId,
+		unitId,
+		status,
+		receivedAt,
+		source,
+	}: UpdateUnitStatusCommand): Promise<void> {
+		const unitStatus = new UnitStatus();
+		unitStatus.status = status;
+		unitStatus.receivedAt = receivedAt;
+		unitStatus.source = source;
+
+		await unitStatus.validOrThrow();
+
+		const updateSucceeded = await this.repository.updateStatus(
+			orgId,
+			unitId,
+			unitStatus,
+		);
+
+		if (!updateSucceeded) {
+			this.logger.warn(`Unit ${unitId} status update failed: outdated status`);
+			throw new UnitStatusOutdatedException();
+		}
+
+		this.eventBus.publish(
+			new UnitStatusUpdatedEvent(orgId, unitId, unitStatus),
+		);
+
+		this.logger.log(`Unit ${unitId} status updated`, unitStatus);
+	}
+}

--- a/libs/api/unit/src/lib/core/entity/alert-group.entity.ts
+++ b/libs/api/unit/src/lib/core/entity/alert-group.entity.ts
@@ -1,0 +1,17 @@
+import { AutoMap } from '@automapper/classes';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+import { BaseEntityModel } from '@kordis/api/shared';
+
+import { UnitEntity } from './unit.entity';
+
+@ObjectType('AlertGroup')
+export class AlertGroupEntity extends BaseEntityModel {
+	@Field()
+	@AutoMap()
+	name: string;
+
+	@Field(() => [UnitEntity])
+	@AutoMap(() => [UnitEntity])
+	units: UnitEntity[];
+}

--- a/libs/api/unit/src/lib/core/entity/status.type.ts
+++ b/libs/api/unit/src/lib/core/entity/status.type.ts
@@ -1,0 +1,5 @@
+// contains the status codes, that can be stored on a unit
+
+export const ALLOWED_PERSISTENT_UNIT_STATUS = [1, 2, 3, 4, 6, 7, 8, 9];
+export type PersistentUnitStatus =
+	(typeof ALLOWED_PERSISTENT_UNIT_STATUS)[number];

--- a/libs/api/unit/src/lib/core/entity/unit.entity.ts
+++ b/libs/api/unit/src/lib/core/entity/unit.entity.ts
@@ -1,0 +1,104 @@
+import { AutoMap } from '@automapper/classes';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Type } from 'class-transformer';
+import {
+	IsDate,
+	IsIn,
+	IsInt,
+	IsNotEmpty,
+	IsString,
+	ValidateIf,
+	ValidateNested,
+} from 'class-validator';
+
+import { BaseEntityModel, Validatable } from '@kordis/api/shared';
+
+import {
+	ALLOWED_PERSISTENT_UNIT_STATUS,
+	PersistentUnitStatus,
+} from './status.type';
+
+@ObjectType()
+export class FurtherAttribute {
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	name: string;
+
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	value: string;
+}
+
+@ObjectType()
+export class UnitStatus extends Validatable {
+	@Field(() => Number)
+	@IsInt()
+	@IsIn(ALLOWED_PERSISTENT_UNIT_STATUS)
+	@AutoMap(() => Number)
+	status: PersistentUnitStatus;
+
+	@Field(() => String)
+	@IsDate()
+	@AutoMap()
+	receivedAt: Date;
+
+	@Field()
+	@IsString()
+	@AutoMap()
+	source: string;
+}
+
+@ObjectType('Unit')
+export class UnitEntity extends BaseEntityModel {
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	name: string;
+
+	@Field(() => UnitStatus, { nullable: true })
+	@ValidateNested()
+	@Type(() => UnitStatus)
+	@ValidateIf((unit) => unit.status !== null)
+	@AutoMap(() => UnitStatus)
+	status: UnitStatus | null;
+
+	@Field()
+	@IsString()
+	@AutoMap()
+	note: string;
+
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	department: string;
+
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	rcsId: string;
+
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	callSign: string;
+
+	@Field()
+	@IsString()
+	@IsNotEmpty()
+	@AutoMap()
+	callSignAbbreviation: string;
+
+	@Field(() => [FurtherAttribute])
+	@ValidateNested({ each: true })
+	@Type(() => FurtherAttribute)
+	@AutoMap()
+	furtherAttributes: FurtherAttribute[];
+}

--- a/libs/api/unit/src/lib/core/event/unit-status-updated.event.ts
+++ b/libs/api/unit/src/lib/core/event/unit-status-updated.event.ts
@@ -1,0 +1,11 @@
+export class UnitStatusUpdatedEvent {
+	constructor(
+		readonly orgId: string,
+		readonly unitId: string,
+		readonly status: {
+			status: number;
+			receivedAt: Date;
+			source: string;
+		},
+	) {}
+}

--- a/libs/api/unit/src/lib/core/exception/unit-not-found.exception.ts
+++ b/libs/api/unit/src/lib/core/exception/unit-not-found.exception.ts
@@ -1,0 +1,5 @@
+export class UnitNotFoundException extends Error {
+	constructor() {
+		super('Unit not found.');
+	}
+}

--- a/libs/api/unit/src/lib/core/exception/unit-status-outdated.exception.ts
+++ b/libs/api/unit/src/lib/core/exception/unit-status-outdated.exception.ts
@@ -1,0 +1,5 @@
+export class UnitStatusOutdatedException extends Error {
+	constructor() {
+		super('Unit status outdated.');
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-alert-group-by-id.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-group-by-id.query.ts
@@ -7,16 +7,16 @@ import {
 	AlertGroupRepository,
 } from '../repository/alert-group.repository';
 
-export class GetAlertGroupsByIdQuery {
+export class GetAlertGroupByIdQuery {
 	constructor(
 		readonly orgId: string,
 		readonly id: string,
 	) {}
 }
 
-@QueryHandler(GetAlertGroupsByIdQuery)
-export class GetAlertGroupsByIdHandler
-	implements IQueryHandler<GetAlertGroupsByIdQuery>
+@QueryHandler(GetAlertGroupByIdQuery)
+export class GetAlertGroupByIdHandler
+	implements IQueryHandler<GetAlertGroupByIdQuery>
 {
 	constructor(
 		@Inject(ALERT_GROUP_REPOSITORY)
@@ -26,7 +26,7 @@ export class GetAlertGroupsByIdHandler
 	async execute({
 		orgId,
 		id,
-	}: GetAlertGroupsByIdQuery): Promise<AlertGroupEntity> {
+	}: GetAlertGroupByIdQuery): Promise<AlertGroupEntity> {
 		return this.repository.findById(orgId, id);
 	}
 }

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.spec.ts
@@ -5,16 +5,16 @@ import {
 	ALERT_GROUP_REPOSITORY,
 	AlertGroupRepository,
 } from '../repository/alert-group.repository';
-import { GetAlertGroupsByIdHandler } from './get-alert-groups-by-id.query';
+import { GetAlertGroupByIdHandler } from './get-alert-group-by-id.query';
 
 describe('GetAlertGroupsByIdHandler', () => {
-	let getAlertGroupsByIdHandler: GetAlertGroupsByIdHandler;
+	let getAlertGroupsByIdHandler: GetAlertGroupByIdHandler;
 	let mockAlertGroupRepository: jest.Mocked<AlertGroupRepository>;
 
 	beforeEach(async () => {
 		const moduleRef = await Test.createTestingModule({
 			providers: [
-				GetAlertGroupsByIdHandler,
+				GetAlertGroupByIdHandler,
 				{
 					provide: ALERT_GROUP_REPOSITORY,
 					useValue: {
@@ -24,8 +24,8 @@ describe('GetAlertGroupsByIdHandler', () => {
 			],
 		}).compile();
 
-		getAlertGroupsByIdHandler = moduleRef.get<GetAlertGroupsByIdHandler>(
-			GetAlertGroupsByIdHandler,
+		getAlertGroupsByIdHandler = moduleRef.get<GetAlertGroupByIdHandler>(
+			GetAlertGroupByIdHandler,
 		);
 		mockAlertGroupRepository = moduleRef.get<jest.Mocked<AlertGroupRepository>>(
 			ALERT_GROUP_REPOSITORY,

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.spec.ts
@@ -1,0 +1,52 @@
+import { Test } from '@nestjs/testing';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+import { GetAlertGroupsByIdHandler } from './get-alert-groups-by-id.query';
+
+describe('GetAlertGroupsByIdHandler', () => {
+	let getAlertGroupsByIdHandler: GetAlertGroupsByIdHandler;
+	let mockAlertGroupRepository: jest.Mocked<AlertGroupRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetAlertGroupsByIdHandler,
+				{
+					provide: ALERT_GROUP_REPOSITORY,
+					useValue: {
+						findById: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getAlertGroupsByIdHandler = moduleRef.get<GetAlertGroupsByIdHandler>(
+			GetAlertGroupsByIdHandler,
+		);
+		mockAlertGroupRepository = moduleRef.get<jest.Mocked<AlertGroupRepository>>(
+			ALERT_GROUP_REPOSITORY,
+		);
+	});
+
+	it('should return alert group by organization id and alert group id', async () => {
+		const mockAlertGroup = new AlertGroupEntity();
+		mockAlertGroup.name = 'Test Alert Group';
+
+		mockAlertGroupRepository.findById.mockResolvedValue(mockAlertGroup);
+
+		const result = await getAlertGroupsByIdHandler.execute({
+			orgId: 'orgId',
+			id: '1',
+		});
+
+		expect(result).toEqual(mockAlertGroup);
+		expect(mockAlertGroupRepository.findById).toHaveBeenCalledWith(
+			'orgId',
+			'1',
+		);
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-id.query.ts
@@ -1,0 +1,32 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+
+export class GetAlertGroupsByIdQuery {
+	constructor(
+		readonly orgId: string,
+		readonly id: string,
+	) {}
+}
+
+@QueryHandler(GetAlertGroupsByIdQuery)
+export class GetAlertGroupsByIdHandler
+	implements IQueryHandler<GetAlertGroupsByIdQuery>
+{
+	constructor(
+		@Inject(ALERT_GROUP_REPOSITORY)
+		private readonly repository: AlertGroupRepository,
+	) {}
+
+	async execute({
+		orgId,
+		id,
+	}: GetAlertGroupsByIdQuery): Promise<AlertGroupEntity> {
+		return this.repository.findById(orgId, id);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.spec.ts
@@ -1,0 +1,49 @@
+import { Test } from '@nestjs/testing';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+import { GetAlertGroupsByIdsHandler } from './get-alert-groups-by-ids.query';
+
+describe('GetAlertGroupsByIdsHandler', () => {
+	let getAlertGroupsByIdsHandler: GetAlertGroupsByIdsHandler;
+	let mockAlertGroupRepository: jest.Mocked<AlertGroupRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetAlertGroupsByIdsHandler,
+				{
+					provide: ALERT_GROUP_REPOSITORY,
+					useValue: {
+						findByIds: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getAlertGroupsByIdsHandler = moduleRef.get<GetAlertGroupsByIdsHandler>(
+			GetAlertGroupsByIdsHandler,
+		);
+		mockAlertGroupRepository = moduleRef.get<jest.Mocked<AlertGroupRepository>>(
+			ALERT_GROUP_REPOSITORY,
+		);
+	});
+
+	it('should return alert groups by ids', async () => {
+		const entity1 = new AlertGroupEntity();
+		entity1.name = 'Alert Group 1';
+		const entity2 = new AlertGroupEntity();
+		entity2.name = 'Alert Group 2';
+		mockAlertGroupRepository.findByIds.mockResolvedValue([entity1, entity2]);
+
+		const result = await getAlertGroupsByIdsHandler.execute({
+			ids: ['1', '2'],
+		});
+
+		expect(result).toEqual([entity1, entity2]);
+		expect(mockAlertGroupRepository.findByIds).toHaveBeenCalledWith(['1', '2']);
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.ts
@@ -1,0 +1,28 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+
+export class GetAlertGroupsByIdsQuery {
+	constructor(readonly ids: string[]) {}
+}
+
+@QueryHandler(GetAlertGroupsByIdsQuery)
+export class GetAlertGroupsByIdsHandler
+	implements IQueryHandler<GetAlertGroupsByIdsQuery>
+{
+	constructor(
+		@Inject(ALERT_GROUP_REPOSITORY)
+		private readonly repository: AlertGroupRepository,
+	) {}
+
+	async execute({
+		ids,
+	}: GetAlertGroupsByIdsQuery): Promise<AlertGroupEntity[]> {
+		return this.repository.findByIds(ids);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by.org.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by.org.query.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+import { GetAlertGroupsByOrgHandler } from './get-alert-groups-by.org.query';
+
+describe('GetAlertGroupsByOrgHandler', () => {
+	let getAlertGroupsByOrgHandler: GetAlertGroupsByOrgHandler;
+	let mockAlertGroupRepository: jest.Mocked<AlertGroupRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetAlertGroupsByOrgHandler,
+				{
+					provide: ALERT_GROUP_REPOSITORY,
+					useValue: {
+						findByOrgId: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getAlertGroupsByOrgHandler = moduleRef.get<GetAlertGroupsByOrgHandler>(
+			GetAlertGroupsByOrgHandler,
+		);
+		mockAlertGroupRepository = moduleRef.get<jest.Mocked<AlertGroupRepository>>(
+			ALERT_GROUP_REPOSITORY,
+		);
+	});
+
+	it('should return alert groups by organization id', async () => {
+		const mockAlertGroup = new AlertGroupEntity();
+		mockAlertGroup.name = 'Test Alert Group';
+
+		mockAlertGroupRepository.findByOrgId.mockResolvedValue([mockAlertGroup]);
+
+		const result = await getAlertGroupsByOrgHandler.execute({ orgId: 'orgId' });
+
+		expect(result).toEqual([mockAlertGroup]);
+		expect(mockAlertGroupRepository.findByOrgId).toHaveBeenCalledWith('orgId');
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by.org.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by.org.query.ts
@@ -1,0 +1,28 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+import {
+	ALERT_GROUP_REPOSITORY,
+	AlertGroupRepository,
+} from '../repository/alert-group.repository';
+
+export class GetAlertGroupsByOrgQuery {
+	constructor(readonly orgId: string) {}
+}
+
+@QueryHandler(GetAlertGroupsByOrgQuery)
+export class GetAlertGroupsByOrgHandler
+	implements IQueryHandler<GetAlertGroupsByOrgQuery>
+{
+	constructor(
+		@Inject(ALERT_GROUP_REPOSITORY)
+		private readonly repository: AlertGroupRepository,
+	) {}
+
+	async execute({
+		orgId,
+	}: GetAlertGroupsByOrgQuery): Promise<AlertGroupEntity[]> {
+		return this.repository.findByOrgId(orgId);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-unit-by-id.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-unit-by-id.query.spec.ts
@@ -1,0 +1,43 @@
+import { Test } from '@nestjs/testing';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import { GetUnitByIdHandler } from './get-unit-by-id.query';
+
+describe('GetUnitByIdHandler', () => {
+	let getUnitByIdHandler: GetUnitByIdHandler;
+	let mockUnitRepository: jest.Mocked<UnitRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetUnitByIdHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						findById: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getUnitByIdHandler = moduleRef.get<GetUnitByIdHandler>(GetUnitByIdHandler);
+		mockUnitRepository =
+			moduleRef.get<jest.Mocked<UnitRepository>>(UNIT_REPOSITORY);
+	});
+
+	it('should return unit by organization id and unit id', async () => {
+		const mockUnit = new UnitEntity();
+		mockUnit.name = 'Test Unit';
+
+		mockUnitRepository.findById.mockResolvedValue(mockUnit);
+
+		const result = await getUnitByIdHandler.execute({
+			orgId: 'orgId',
+			id: '1',
+		});
+
+		expect(result).toEqual(mockUnit);
+		expect(mockUnitRepository.findById).toHaveBeenCalledWith('orgId', '1');
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-unit-by-id.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-unit-by-id.query.ts
@@ -1,0 +1,24 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class GetUnitByIdQuery {
+	constructor(
+		readonly orgId: string,
+		readonly id: string,
+	) {}
+}
+
+@QueryHandler(GetUnitByIdQuery)
+export class GetUnitByIdHandler implements IQueryHandler<GetUnitByIdQuery> {
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+	) {}
+
+	async execute({ orgId, id }: GetUnitByIdQuery): Promise<UnitEntity> {
+		return this.repository.findById(orgId, id);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-unit-by-rcs-id.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-unit-by-rcs-id.query.spec.ts
@@ -1,0 +1,48 @@
+import { Test } from '@nestjs/testing';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import { GetUnitByRCSIDHandler } from './get-unit-by-rcs-id.query';
+
+describe('GetUnitByRCSIDHandler', () => {
+	let getUnitByRCSIDHandler: GetUnitByRCSIDHandler;
+	let mockUnitRepository: jest.Mocked<UnitRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetUnitByRCSIDHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						findByRcsId: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getUnitByRCSIDHandler = moduleRef.get<GetUnitByRCSIDHandler>(
+			GetUnitByRCSIDHandler,
+		);
+		mockUnitRepository =
+			moduleRef.get<jest.Mocked<UnitRepository>>(UNIT_REPOSITORY);
+	});
+
+	it('should return unit by organization id and RCS id', async () => {
+		const mockUnit = new UnitEntity();
+		mockUnit.name = 'Test Unit';
+
+		mockUnitRepository.findByRcsId.mockResolvedValue(mockUnit);
+
+		const result = await getUnitByRCSIDHandler.execute({
+			orgId: 'orgId',
+			rcsId: 'rcsId',
+		});
+
+		expect(result).toEqual(mockUnit);
+		expect(mockUnitRepository.findByRcsId).toHaveBeenCalledWith(
+			'orgId',
+			'rcsId',
+		);
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-unit-by-rcs-id.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-unit-by-rcs-id.query.ts
@@ -1,0 +1,26 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class GetUnitByRCSIDQuery {
+	constructor(
+		readonly orgId: string,
+		readonly rcsId: string,
+	) {}
+}
+
+@QueryHandler(GetUnitByRCSIDQuery)
+export class GetUnitByRCSIDHandler
+	implements IQueryHandler<GetUnitByRCSIDQuery>
+{
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+	) {}
+
+	async execute({ orgId, rcsId }: GetUnitByRCSIDQuery): Promise<UnitEntity> {
+		return this.repository.findByRcsId(orgId, rcsId);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-units-by-ids.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-units-by-ids.query.spec.ts
@@ -1,0 +1,44 @@
+import { Test } from '@nestjs/testing';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import { GetUnitsByIdsHandler } from './get-units-by-ids.query';
+
+describe('GetUnitsByIdsHandler', () => {
+	let getUnitsByIdsHandler: GetUnitsByIdsHandler;
+	let mockUnitRepository: jest.Mocked<UnitRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetUnitsByIdsHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						findByIds: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getUnitsByIdsHandler =
+			moduleRef.get<GetUnitsByIdsHandler>(GetUnitsByIdsHandler);
+		mockUnitRepository =
+			moduleRef.get<jest.Mocked<UnitRepository>>(UNIT_REPOSITORY);
+	});
+
+	it('should return units by ids', async () => {
+		const entity1 = new UnitEntity();
+		entity1.name = 'unit1';
+
+		const entity2 = new UnitEntity();
+		entity2.name = 'unit2';
+
+		mockUnitRepository.findByIds.mockResolvedValue([entity1, entity2]);
+
+		const result = await getUnitsByIdsHandler.execute({ ids: ['1', '2'] });
+
+		expect(result).toEqual([entity1, entity2]);
+		expect(mockUnitRepository.findByIds).toHaveBeenCalledWith(['1', '2']);
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-units-by-ids.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-units-by-ids.query.ts
@@ -1,0 +1,21 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class GetUnitsByIdsQuery {
+	constructor(readonly ids: string[]) {}
+}
+
+@QueryHandler(GetUnitsByIdsQuery)
+export class GetUnitsByIdsHandler implements IQueryHandler<GetUnitsByIdsQuery> {
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+	) {}
+
+	async execute({ ids }: GetUnitsByIdsQuery): Promise<UnitEntity[]> {
+		return this.repository.findByIds(ids);
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-units-by-org.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-units-by-org.query.spec.ts
@@ -1,0 +1,43 @@
+import { Test } from '@nestjs/testing';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+import { GetUnitsByOrgHandler } from './get-units-by-org.query';
+
+describe('GetUnitsByOrgHandler', () => {
+	let getUnitsByOrgHandler: GetUnitsByOrgHandler;
+	let mockUnitRepository: jest.Mocked<UnitRepository>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				GetUnitsByOrgHandler,
+				{
+					provide: UNIT_REPOSITORY,
+					useValue: {
+						findByOrg: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		getUnitsByOrgHandler =
+			moduleRef.get<GetUnitsByOrgHandler>(GetUnitsByOrgHandler);
+		mockUnitRepository =
+			moduleRef.get<jest.Mocked<UnitRepository>>(UNIT_REPOSITORY);
+	});
+
+	it('should return units by organization id', async () => {
+		const entity1 = new UnitEntity();
+		entity1.name = 'name1';
+
+		const entity2 = new UnitEntity();
+		entity2.name = 'name2';
+		mockUnitRepository.findByOrg.mockResolvedValue([entity1, entity2]);
+
+		const result = await getUnitsByOrgHandler.execute({ orgId: 'orgId' });
+
+		expect(result).toEqual([entity1, entity2]);
+		expect(mockUnitRepository.findByOrg).toHaveBeenCalledWith('orgId');
+	});
+});

--- a/libs/api/unit/src/lib/core/query/get-units-by-org.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-units-by-org.query.ts
@@ -1,0 +1,21 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { UnitEntity } from '../entity/unit.entity';
+import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
+
+export class GetUnitsByOrgQuery {
+	constructor(readonly orgId: string) {}
+}
+
+@QueryHandler(GetUnitsByOrgQuery)
+export class GetUnitsByOrgHandler implements IQueryHandler<GetUnitsByOrgQuery> {
+	constructor(
+		@Inject(UNIT_REPOSITORY)
+		private readonly repository: UnitRepository,
+	) {}
+
+	async execute({ orgId }: GetUnitsByOrgQuery): Promise<UnitEntity[]> {
+		return this.repository.findByOrg(orgId);
+	}
+}

--- a/libs/api/unit/src/lib/core/repository/alert-group.repository.ts
+++ b/libs/api/unit/src/lib/core/repository/alert-group.repository.ts
@@ -1,0 +1,11 @@
+import { AlertGroupEntity } from '../entity/alert-group.entity';
+
+export const ALERT_GROUP_REPOSITORY = Symbol('ALERT_GROUP_REPOSITORY');
+
+export interface AlertGroupRepository {
+	findByIds(ids: string[]): Promise<AlertGroupEntity[]>;
+
+	findById(orgId: string, id: string): Promise<AlertGroupEntity>;
+
+	findByOrgId(orgId: string): Promise<AlertGroupEntity[]>;
+}

--- a/libs/api/unit/src/lib/core/repository/unit.repository.ts
+++ b/libs/api/unit/src/lib/core/repository/unit.repository.ts
@@ -1,0 +1,17 @@
+import { UnitEntity, UnitStatus } from '../entity/unit.entity';
+
+export const UNIT_REPOSITORY = Symbol('UNIT_REPOSITORY');
+
+export interface UnitRepository {
+	findByIds(ids: string[]): Promise<UnitEntity[]>;
+
+	findById(orgId: string, id: string): Promise<UnitEntity>;
+
+	findByOrg(orgId: string): Promise<UnitEntity[]>;
+
+	findByRcsId(orgId: string, rcsId: string): Promise<UnitEntity>;
+
+	updateNote(orgId: string, id: string, note: string): Promise<boolean>;
+
+	updateStatus(orgId: string, id: string, status: UnitStatus): Promise<boolean>;
+}

--- a/libs/api/unit/src/lib/infra/alert-group.view-model.ts
+++ b/libs/api/unit/src/lib/infra/alert-group.view-model.ts
@@ -1,0 +1,1 @@
+export { AlertGroupEntity as AlertGroupViewModel } from '../core/entity/alert-group.entity';

--- a/libs/api/unit/src/lib/infra/controller/alert-group.resolver.spec.ts
+++ b/libs/api/unit/src/lib/infra/controller/alert-group.resolver.spec.ts
@@ -1,0 +1,65 @@
+import { QueryBus } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+
+import { AuthUser } from '@kordis/shared/model';
+
+import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
+import { GetAlertGroupsByIdQuery } from '../../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupsByOrgQuery } from '../../core/query/get-alert-groups-by.org.query';
+import { AlertGroupResolver } from './alert-group.resolver';
+
+describe('AlertGroupResolver', () => {
+	let alertGroupResolver: AlertGroupResolver;
+	let mockQueryBus: jest.Mocked<QueryBus>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			providers: [
+				AlertGroupResolver,
+				{
+					provide: QueryBus,
+					useValue: {
+						execute: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		alertGroupResolver = moduleRef.get<AlertGroupResolver>(AlertGroupResolver);
+		mockQueryBus = moduleRef.get<jest.Mocked<QueryBus>>(QueryBus);
+	});
+
+	it('should return alert groups by organization id', async () => {
+		const alertGroup1 = new AlertGroupEntity();
+		alertGroup1.name = 'alertGroup1';
+		const alertGroup2 = new AlertGroupEntity();
+		alertGroup2.name = 'alertGroup2';
+		const mockAlertGroups = [alertGroup1, alertGroup2];
+
+		mockQueryBus.execute.mockResolvedValue(mockAlertGroups);
+
+		const result = await alertGroupResolver.alertGroups({
+			organizationId: 'orgId',
+		} as AuthUser);
+
+		expect(result).toEqual(mockAlertGroups);
+		expect(mockQueryBus.execute).toHaveBeenCalledWith(
+			new GetAlertGroupsByOrgQuery('orgId'),
+		);
+	});
+
+	it('should return alert group by organization id and id', async () => {
+		const mockAlertGroup = new AlertGroupEntity();
+		mockAlertGroup.name = 'alertGroup';
+		mockQueryBus.execute.mockResolvedValue(mockAlertGroup);
+
+		const result = await alertGroupResolver.alertGroup('id', {
+			organizationId: 'orgId',
+		} as AuthUser);
+
+		expect(result).toEqual(mockAlertGroup);
+		expect(mockQueryBus.execute).toHaveBeenCalledWith(
+			new GetAlertGroupsByIdQuery('orgId', 'id'),
+		);
+	});
+});

--- a/libs/api/unit/src/lib/infra/controller/alert-group.resolver.spec.ts
+++ b/libs/api/unit/src/lib/infra/controller/alert-group.resolver.spec.ts
@@ -4,7 +4,7 @@ import { Test } from '@nestjs/testing';
 import { AuthUser } from '@kordis/shared/model';
 
 import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
-import { GetAlertGroupsByIdQuery } from '../../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupByIdQuery } from '../../core/query/get-alert-group-by-id.query';
 import { GetAlertGroupsByOrgQuery } from '../../core/query/get-alert-groups-by.org.query';
 import { AlertGroupResolver } from './alert-group.resolver';
 
@@ -59,7 +59,7 @@ describe('AlertGroupResolver', () => {
 
 		expect(result).toEqual(mockAlertGroup);
 		expect(mockQueryBus.execute).toHaveBeenCalledWith(
-			new GetAlertGroupsByIdQuery('orgId', 'id'),
+			new GetAlertGroupByIdQuery('orgId', 'id'),
 		);
 	});
 });

--- a/libs/api/unit/src/lib/infra/controller/alert-group.resolver.ts
+++ b/libs/api/unit/src/lib/infra/controller/alert-group.resolver.ts
@@ -1,0 +1,33 @@
+import { QueryBus } from '@nestjs/cqrs';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { RequestUser } from '@kordis/api/auth';
+import { AuthUser } from '@kordis/shared/model';
+
+import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
+import { UnitEntity } from '../../core/entity/unit.entity';
+import { GetAlertGroupsByIdQuery } from '../../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupsByOrgQuery } from '../../core/query/get-alert-groups-by.org.query';
+import { AlertGroupViewModel } from '../alert-group.view-model';
+
+@Resolver()
+export class AlertGroupResolver {
+	constructor(private readonly queryBus: QueryBus) {}
+
+	@Query(() => [AlertGroupViewModel])
+	alertGroups(
+		@RequestUser() { organizationId }: AuthUser,
+	): Promise<UnitEntity[]> {
+		return this.queryBus.execute(new GetAlertGroupsByOrgQuery(organizationId));
+	}
+
+	@Query(() => AlertGroupViewModel)
+	async alertGroup(
+		@Args('id') id: string,
+		@RequestUser() { organizationId }: AuthUser,
+	): Promise<AlertGroupEntity[]> {
+		return this.queryBus.execute(
+			new GetAlertGroupsByIdQuery(organizationId, id),
+		);
+	}
+}

--- a/libs/api/unit/src/lib/infra/controller/alert-group.resolver.ts
+++ b/libs/api/unit/src/lib/infra/controller/alert-group.resolver.ts
@@ -6,7 +6,7 @@ import { AuthUser } from '@kordis/shared/model';
 
 import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
 import { UnitEntity } from '../../core/entity/unit.entity';
-import { GetAlertGroupsByIdQuery } from '../../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupByIdQuery } from '../../core/query/get-alert-group-by-id.query';
 import { GetAlertGroupsByOrgQuery } from '../../core/query/get-alert-groups-by.org.query';
 import { AlertGroupViewModel } from '../alert-group.view-model';
 
@@ -27,7 +27,7 @@ export class AlertGroupResolver {
 		@RequestUser() { organizationId }: AuthUser,
 	): Promise<AlertGroupEntity[]> {
 		return this.queryBus.execute(
-			new GetAlertGroupsByIdQuery(organizationId, id),
+			new GetAlertGroupByIdQuery(organizationId, id),
 		);
 	}
 }

--- a/libs/api/unit/src/lib/infra/controller/unit.resolver.spec.ts
+++ b/libs/api/unit/src/lib/infra/controller/unit.resolver.spec.ts
@@ -1,0 +1,217 @@
+import { createMock } from '@golevelup/ts-jest';
+import { CommandBus, CqrsModule, EventBus, QueryBus } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+
+import {
+	GraphQLSubscriptionService,
+	PresentableValidationException,
+	ValidationException,
+} from '@kordis/api/shared';
+import { expectIterableNotToHaveNext } from '@kordis/api/test-helpers';
+import { AuthUser } from '@kordis/shared/model';
+
+import { UpdateUnitNoteCommand } from '../../core/command/update-unit-note.command';
+import { UpdateUnitStatusCommand } from '../../core/command/update-unit-status.command';
+import { UnitEntity } from '../../core/entity/unit.entity';
+import { UnitStatusUpdatedEvent } from '../../core/event/unit-status-updated.event';
+import { UnitStatusOutdatedException } from '../../core/exception/unit-status-outdated.exception';
+import { PresentableUnitStatusOutdatedException } from '../exceptions/presentable-unit-status-outdated.exception';
+import { UnitResolver } from './unit.resolver';
+
+describe('UnitResolver', () => {
+	let unitResolver: UnitResolver;
+	let mockCommandBus: jest.Mocked<CommandBus>;
+	let mockQueryBus: jest.Mocked<QueryBus>;
+	let eventBus: EventBus;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [CqrsModule],
+			providers: [UnitResolver, GraphQLSubscriptionService],
+		})
+			.overrideProvider(CommandBus)
+			.useValue(createMock<CommandBus>())
+			.overrideProvider(QueryBus)
+			.useValue(createMock<QueryBus>())
+			.compile();
+
+		unitResolver = moduleRef.get<UnitResolver>(UnitResolver);
+		mockCommandBus = moduleRef.get<jest.Mocked<CommandBus>>(CommandBus);
+		mockQueryBus = moduleRef.get<jest.Mocked<QueryBus>>(QueryBus);
+		eventBus = moduleRef.get<EventBus>(EventBus);
+	});
+
+	it('should return units by organization id', async () => {
+		const unit1 = new UnitEntity();
+		unit1.name = 'unit1';
+		const unit2 = new UnitEntity();
+		unit2.name = 'unit2';
+		const mockUnits = [unit1, unit2];
+
+		mockQueryBus.execute.mockResolvedValue(mockUnits);
+
+		const result = await unitResolver.units({
+			organizationId: 'orgId',
+		} as AuthUser);
+
+		expect(result).toEqual(mockUnits);
+	});
+
+	it('should return unit by organization id and id', async () => {
+		const mockUnit = new UnitEntity();
+		mockUnit.name = 'unit';
+
+		mockQueryBus.execute.mockResolvedValue(mockUnit);
+
+		const result = await unitResolver.unit('id', {
+			organizationId: 'orgId',
+		} as AuthUser);
+
+		expect(result).toEqual(mockUnit);
+	});
+
+	it('should update unit note', async () => {
+		const mockUnit = new UnitEntity();
+		mockUnit.name = 'unit';
+
+		mockQueryBus.execute.mockResolvedValue(mockUnit);
+
+		const result = await unitResolver.updateUnitNote(
+			{ organizationId: 'orgId' } as AuthUser,
+			'id',
+			'note',
+		);
+
+		expect(result).toEqual(mockUnit);
+		expect(mockCommandBus.execute).toHaveBeenCalledWith(
+			new UpdateUnitNoteCommand('orgId', 'id', 'note'),
+		);
+	});
+
+	describe('updateUnitStatus', () => {
+		it('should update unit status', async () => {
+			const mockUnit = new UnitEntity();
+			mockUnit.name = 'unit';
+
+			mockQueryBus.execute.mockResolvedValue(mockUnit);
+
+			const result = await unitResolver.updateUnitStatus(
+				{
+					organizationId: 'orgId',
+					firstName: 'First',
+					lastName: 'Last',
+				} as AuthUser,
+				'id',
+				1,
+			);
+
+			expect(result).toEqual(mockUnit);
+			expect(mockCommandBus.execute).toHaveBeenCalledWith(
+				new UpdateUnitStatusCommand(
+					'orgId',
+					'id',
+					1,
+					expect.any(Date),
+					'First Last',
+				),
+			);
+		});
+
+		it('should throw PresentableValidationException when ValidationException is thrown', async () => {
+			mockCommandBus.execute.mockRejectedValueOnce(new ValidationException([]));
+
+			await expect(
+				unitResolver.updateUnitStatus(
+					{
+						organizationId: 'orgId',
+						firstName: 'First',
+						lastName: 'Last',
+					} as AuthUser,
+					'id',
+					1,
+				),
+			).rejects.toThrow(PresentableValidationException);
+		});
+
+		it('should throw PresentableUnitStatusOutdatedException when UnitStatusOutdatedException is thrown', async () => {
+			mockCommandBus.execute.mockRejectedValueOnce(
+				new UnitStatusOutdatedException(),
+			);
+
+			await expect(
+				unitResolver.updateUnitStatus(
+					{
+						organizationId: 'orgId',
+						firstName: 'First',
+						lastName: 'Last',
+					} as AuthUser,
+					'id',
+					1,
+				),
+			).rejects.toThrow(PresentableUnitStatusOutdatedException);
+		});
+
+		it('should throw error when an unknown error is thrown', async () => {
+			const error = new Error('Unknown error');
+			mockCommandBus.execute.mockRejectedValueOnce(error);
+
+			await expect(
+				unitResolver.updateUnitStatus(
+					{
+						organizationId: 'orgId',
+						firstName: 'First',
+						lastName: 'Last',
+					} as AuthUser,
+					'id',
+					1,
+				),
+			).rejects.toThrow(error);
+		});
+	});
+
+	describe('unitStatusUpdated', () => {
+		it('should emit if UnitStatusUpdatedEvent fired', async () => {
+			const mockUnit = new UnitEntity();
+			mockUnit.name = 'unit';
+
+			mockQueryBus.execute.mockResolvedValue(mockUnit);
+
+			const subscriptionIterable = unitResolver.unitStatusUpdated({
+				id: 'userid',
+				organizationId: 'orgId',
+			} as AuthUser);
+
+			eventBus.publish(
+				new UnitStatusUpdatedEvent('orgId', 'unitId', {
+					status: 1,
+					receivedAt: new Date(),
+					source: 'someSource',
+				}),
+			);
+
+			await expect(subscriptionIterable.next()).resolves.toEqual(
+				expect.objectContaining({
+					value: {
+						unitStatusUpdated: mockUnit,
+					},
+				}),
+			);
+		});
+
+		it('should not emi if UnitStatusUpdatedEvent fired for different org', async () => {
+			const subscriptionIterable = unitResolver.unitStatusUpdated({
+				id: 'userid',
+				organizationId: 'someOtherOrgId',
+			} as AuthUser);
+			eventBus.publish(
+				new UnitStatusUpdatedEvent('orgId', 'unitId', {
+					status: 1,
+					receivedAt: new Date(),
+					source: 'someSource',
+				}),
+			);
+
+			await expectIterableNotToHaveNext(subscriptionIterable);
+		});
+	});
+});

--- a/libs/api/unit/src/lib/infra/controller/unit.resolver.ts
+++ b/libs/api/unit/src/lib/infra/controller/unit.resolver.ts
@@ -1,0 +1,115 @@
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import {
+	Args,
+	Int,
+	Mutation,
+	Query,
+	Resolver,
+	Subscription,
+} from '@nestjs/graphql';
+
+import { RequestUser } from '@kordis/api/auth';
+import {
+	GraphQLSubscriptionService,
+	PresentableValidationException,
+	ValidationException,
+} from '@kordis/api/shared';
+import { AuthUser } from '@kordis/shared/model';
+
+import { UpdateUnitNoteCommand } from '../../core/command/update-unit-note.command';
+import { UpdateUnitStatusCommand } from '../../core/command/update-unit-status.command';
+import { UnitEntity } from '../../core/entity/unit.entity';
+import { UnitStatusUpdatedEvent } from '../../core/event/unit-status-updated.event';
+import { UnitStatusOutdatedException } from '../../core/exception/unit-status-outdated.exception';
+import { GetUnitByIdQuery } from '../../core/query/get-unit-by-id.query';
+import { GetUnitsByOrgQuery } from '../../core/query/get-units-by-org.query';
+import { PresentableUnitStatusOutdatedException } from '../exceptions/presentable-unit-status-outdated.exception';
+import { UnitViewModel } from '../unit.view-model';
+
+@Resolver()
+export class UnitResolver {
+	constructor(
+		private readonly commandBus: CommandBus,
+		private readonly queryBus: QueryBus,
+		private readonly gqlSubscriptionsService: GraphQLSubscriptionService,
+	) {}
+
+	@Query(() => [UnitViewModel])
+	async units(
+		@RequestUser() { organizationId }: AuthUser,
+	): Promise<UnitEntity[]> {
+		return this.queryBus.execute(new GetUnitsByOrgQuery(organizationId));
+	}
+
+	@Query(() => UnitViewModel)
+	async unit(
+		@Args('id') id: string,
+		@RequestUser() { organizationId }: AuthUser,
+	): Promise<UnitEntity[]> {
+		return this.queryBus.execute(new GetUnitByIdQuery(organizationId, id));
+	}
+
+	@Mutation(() => UnitViewModel)
+	async updateUnitNote(
+		@RequestUser() { organizationId }: AuthUser,
+		@Args('unitId') id: string,
+		@Args('note') note: string,
+	): Promise<UnitEntity> {
+		await this.commandBus.execute(
+			new UpdateUnitNoteCommand(organizationId, id, note),
+		);
+
+		return this.queryBus.execute(new GetUnitByIdQuery(organizationId, id));
+	}
+
+	@Mutation(() => UnitViewModel)
+	async updateUnitStatus(
+		@RequestUser() user: AuthUser,
+		@Args('unitId') id: string,
+		@Args('status', { type: () => Int }) status: number,
+	): Promise<UnitEntity> {
+		try {
+			await this.commandBus.execute(
+				new UpdateUnitStatusCommand(
+					user.organizationId,
+					id,
+					status,
+					new Date(),
+					user.firstName + ' ' + user.lastName,
+				),
+			);
+
+			return this.queryBus.execute(
+				new GetUnitByIdQuery(user.organizationId, id),
+			);
+		} catch (error) {
+			if (error instanceof ValidationException) {
+				throw PresentableValidationException.fromCoreValidationException(
+					'Der Status enthalten invalide Werte.',
+					error,
+				);
+			} else if (error instanceof UnitStatusOutdatedException) {
+				throw new PresentableUnitStatusOutdatedException();
+			}
+
+			throw error;
+		}
+	}
+
+	@Subscription(() => UnitViewModel)
+	unitStatusUpdated(
+		@RequestUser() { organizationId }: AuthUser,
+	): AsyncIterableIterator<UnitViewModel> {
+		return this.gqlSubscriptionsService.getSubscriptionIteratorForEvent(
+			UnitStatusUpdatedEvent,
+			'unitStatusUpdated',
+			{
+				filter: (event) => event.orgId === organizationId,
+				map: (event) =>
+					this.queryBus.execute<GetUnitByIdQuery, UnitEntity>(
+						new GetUnitByIdQuery(organizationId, event.unitId),
+					),
+			},
+		);
+	}
+}

--- a/libs/api/unit/src/lib/infra/exceptions/presentable-unit-status-outdated.exception.ts
+++ b/libs/api/unit/src/lib/infra/exceptions/presentable-unit-status-outdated.exception.ts
@@ -1,0 +1,9 @@
+import { PresentableException } from '@kordis/api/shared';
+
+export class PresentableUnitStatusOutdatedException extends PresentableException {
+	readonly code = 'UNIT_STATUS_OUTDATED';
+
+	constructor() {
+		super('Der Status der Einheit wurde in der Zwischenzeit bereits geändert.');
+	}
+}

--- a/libs/api/unit/src/lib/infra/mapper/alert-group.mapper-profile.ts
+++ b/libs/api/unit/src/lib/infra/mapper/alert-group.mapper-profile.ts
@@ -1,0 +1,21 @@
+import { Mapper, createMap } from '@automapper/core';
+import { getMapperToken } from '@automapper/nestjs';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseMapperProfile } from '@kordis/api/shared';
+
+import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
+import { AlertGroupDocument } from '../schema/alert-group.schema';
+
+@Injectable()
+export class AlertGroupProfile extends BaseMapperProfile {
+	constructor(@Inject(getMapperToken()) mapper: Mapper) {
+		super(mapper);
+	}
+
+	override get profile() {
+		return (mapper: Mapper): void => {
+			createMap(mapper, AlertGroupDocument, AlertGroupEntity);
+		};
+	}
+}

--- a/libs/api/unit/src/lib/infra/mapper/unit.mapper-profile.ts
+++ b/libs/api/unit/src/lib/infra/mapper/unit.mapper-profile.ts
@@ -1,0 +1,40 @@
+import { Mapper, createMap } from '@automapper/core';
+import { AutomapperProfile, getMapperToken } from '@automapper/nestjs';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { BaseMapperProfile } from '@kordis/api/shared';
+
+import {
+	FurtherAttribute,
+	FurtherAttribute as FurtherAttributeValueObject,
+	UnitEntity,
+	UnitStatus as UnitStatusValueObject,
+} from '../../core/entity/unit.entity';
+import { UnitDocument, UnitStatus } from '../schema/unit.schema';
+
+@Injectable()
+export class UnitValueObjectProfile extends AutomapperProfile {
+	constructor(@Inject(getMapperToken()) mapper: Mapper) {
+		super(mapper);
+	}
+
+	override get profile() {
+		return (mapper: Mapper): void => {
+			createMap(mapper, UnitStatus, UnitStatusValueObject);
+			createMap(mapper, FurtherAttribute, FurtherAttributeValueObject);
+		};
+	}
+}
+
+@Injectable()
+export class UnitProfile extends BaseMapperProfile {
+	constructor(@Inject(getMapperToken()) mapper: Mapper) {
+		super(mapper);
+	}
+
+	override get profile() {
+		return (mapper: Mapper): void => {
+			createMap(mapper, UnitDocument, UnitEntity);
+		};
+	}
+}

--- a/libs/api/unit/src/lib/infra/repository/alert-group.repository.spec.ts
+++ b/libs/api/unit/src/lib/infra/repository/alert-group.repository.spec.ts
@@ -1,0 +1,120 @@
+import { classes } from '@automapper/classes';
+import { AutomapperModule } from '@automapper/nestjs';
+import { createMock } from '@golevelup/ts-jest';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test } from '@nestjs/testing';
+import { Model, Types } from 'mongoose';
+
+import { BaseModelProfile } from '@kordis/api/shared';
+import {
+	mockModelMethodResult,
+	mockModelMethodResults,
+} from '@kordis/api/test-helpers';
+
+import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
+import { AlertGroupProfile } from '../mapper/alert-group.mapper-profile';
+import { AlertGroupDocument } from '../schema/alert-group.schema';
+import { AlertGroupRepositoryImpl } from './alert-group.repository';
+
+describe('AlertGroupRepositoryImpl', () => {
+	let alertGroupRepository: AlertGroupRepositoryImpl;
+	let mockAlertGroupModel: jest.Mocked<Model<AlertGroupDocument>>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				AutomapperModule.forRoot({
+					strategyInitializer: classes(),
+				}),
+			],
+			providers: [
+				AlertGroupRepositoryImpl,
+				BaseModelProfile,
+				AlertGroupProfile,
+				{
+					provide: getModelToken(AlertGroupDocument.name),
+					useValue: createMock<AlertGroupDocument>(),
+				},
+			],
+		}).compile();
+
+		alertGroupRepository = moduleRef.get<AlertGroupRepositoryImpl>(
+			AlertGroupRepositoryImpl,
+		);
+		mockAlertGroupModel = moduleRef.get<jest.Mocked<Model<AlertGroupDocument>>>(
+			getModelToken(AlertGroupDocument.name),
+		);
+	});
+
+	it('should find alert groups by organization id', async () => {
+		mockModelMethodResults(
+			mockAlertGroupModel,
+			[
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'alertGroup1',
+				},
+				{
+					_id: new Types.ObjectId('662e46a16d91b65f5cfe6cbb'),
+					name: 'alertGroup2',
+				},
+			],
+			'find',
+		);
+
+		const result = await alertGroupRepository.findByOrgId('orgId');
+
+		expect(result[0]).toBeInstanceOf(AlertGroupEntity);
+		expect(result[0].id).toBe('662e469a5213ce0cd9b5c473');
+		expect(result[0].name).toBe('alertGroup1');
+		expect(result[1]).toBeInstanceOf(AlertGroupEntity);
+		expect(result[1].id).toBe('662e46a16d91b65f5cfe6cbb');
+		expect(result[1].name).toBe('alertGroup2');
+	});
+
+	it('should find alert group by id', async () => {
+		mockModelMethodResult(
+			mockAlertGroupModel,
+			{
+				_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+				name: 'alertGroup1',
+			},
+			'findOne',
+		);
+
+		const result = await alertGroupRepository.findById('orgId', 'id');
+
+		expect(result).toBeInstanceOf(AlertGroupEntity);
+		expect(result.id).toBe('662e469a5213ce0cd9b5c473');
+		expect(result.name).toBe('alertGroup1');
+	});
+
+	it('should find alert groups by ids', async () => {
+		mockModelMethodResults(
+			mockAlertGroupModel,
+			[
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'alertGroup1',
+				},
+				{
+					_id: new Types.ObjectId('662e46a16d91b65f5cfe6cbb'),
+					name: 'alertGroup2',
+				},
+			],
+			'find',
+		);
+
+		const result = await alertGroupRepository.findByIds([
+			'662e469a5213ce0cd9b5c473',
+			'662e46a16d91b65f5cfe6cbb',
+		]);
+
+		expect(result[0]).toBeInstanceOf(AlertGroupEntity);
+		expect(result[0].id).toBe('662e469a5213ce0cd9b5c473');
+		expect(result[0].name).toBe('alertGroup1');
+		expect(result[1]).toBeInstanceOf(AlertGroupEntity);
+		expect(result[1].id).toBe('662e46a16d91b65f5cfe6cbb');
+		expect(result[1].name).toBe('alertGroup2');
+	});
+});

--- a/libs/api/unit/src/lib/infra/repository/alert-group.repository.ts
+++ b/libs/api/unit/src/lib/infra/repository/alert-group.repository.ts
@@ -1,0 +1,60 @@
+import { Mapper } from '@automapper/core';
+import { getMapperToken } from '@automapper/nestjs';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { AlertGroupEntity } from '../../core/entity/alert-group.entity';
+import { AlertGroupRepository } from '../../core/repository/alert-group.repository';
+import { AlertGroupDocument } from '../schema/alert-group.schema';
+
+@Injectable()
+export class AlertGroupRepositoryImpl implements AlertGroupRepository {
+	constructor(
+		@InjectModel(AlertGroupDocument.name)
+		private readonly alertGroupModel: Model<AlertGroupDocument>,
+		@Inject(getMapperToken()) private readonly mapper: Mapper,
+	) {}
+
+	async findByOrgId(orgId: string): Promise<AlertGroupEntity[]> {
+		const alertGroups = await this.alertGroupModel
+			.find({ orgId })
+			.populate('units')
+			.lean()
+			.exec();
+
+		return this.mapper.mapArrayAsync(
+			alertGroups,
+			AlertGroupDocument,
+			AlertGroupEntity,
+		);
+	}
+
+	async findById(orgId: string, id: string): Promise<AlertGroupEntity> {
+		const alertGroup = await this.alertGroupModel
+			.findOne({ _id: id, orgId })
+			.populate('units')
+			.lean()
+			.exec();
+
+		return this.mapper.mapAsync(
+			alertGroup,
+			AlertGroupDocument,
+			AlertGroupEntity,
+		);
+	}
+
+	async findByIds(ids: string[]): Promise<AlertGroupEntity[]> {
+		const alertGroups = await this.alertGroupModel
+			.find({ _id: { $in: ids } })
+			.populate('units')
+			.lean()
+			.exec();
+
+		return this.mapper.mapArrayAsync(
+			alertGroups,
+			AlertGroupDocument,
+			AlertGroupEntity,
+		);
+	}
+}

--- a/libs/api/unit/src/lib/infra/repository/unit.repository.spec.ts
+++ b/libs/api/unit/src/lib/infra/repository/unit.repository.spec.ts
@@ -1,0 +1,238 @@
+import { classes } from '@automapper/classes';
+import { AutomapperModule } from '@automapper/nestjs';
+import { createMock } from '@golevelup/ts-jest';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test } from '@nestjs/testing';
+import { Model, Types } from 'mongoose';
+
+import { BaseModelProfile } from '@kordis/api/shared';
+import {
+	mockModelMethodResult,
+	mockModelMethodResults,
+} from '@kordis/api/test-helpers';
+
+import { UnitEntity, UnitStatus } from '../../core/entity/unit.entity';
+import { UnitNotFoundException } from '../../core/exception/unit-not-found.exception';
+import { UnitProfile } from '../mapper/unit.mapper-profile';
+import { UnitDocument } from '../schema/unit.schema';
+import { UnitRepositoryImpl } from './unit.repository';
+
+describe('UnitRepositoryImpl', () => {
+	let unitRepository: UnitRepositoryImpl;
+	let mockUnitModel: jest.Mocked<Model<UnitDocument>>;
+
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				AutomapperModule.forRoot({
+					strategyInitializer: classes(),
+				}),
+			],
+			providers: [
+				UnitRepositoryImpl,
+				BaseModelProfile,
+				UnitProfile,
+				{
+					provide: getModelToken(UnitDocument.name),
+					useValue: createMock<UnitDocument>(),
+				},
+			],
+		}).compile();
+
+		unitRepository = moduleRef.get<UnitRepositoryImpl>(UnitRepositoryImpl);
+		mockUnitModel = moduleRef.get<jest.Mocked<Model<UnitDocument>>>(
+			getModelToken(UnitDocument.name),
+		);
+	});
+
+	it('should find units by ids', async () => {
+		mockModelMethodResults(
+			mockUnitModel,
+			[
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'unit1',
+				},
+				{
+					_id: new Types.ObjectId('662e46a16d91b65f5cfe6cbb'),
+					name: 'unit2',
+				},
+			],
+			'find',
+		);
+
+		const result = await unitRepository.findByIds([
+			'662e469a5213ce0cd9b5c473',
+			'662e46a16d91b65f5cfe6cbb',
+		]);
+
+		expect(result[0]).toBeInstanceOf(UnitEntity);
+		expect(result[0].id).toBe('662e469a5213ce0cd9b5c473');
+		expect(result[0].name).toBe('unit1');
+		expect(result[1]).toBeInstanceOf(UnitEntity);
+		expect(result[1].id).toBe('662e46a16d91b65f5cfe6cbb');
+		expect(result[1].name).toBe('unit2');
+	});
+
+	describe('findById', () => {
+		it('should find unit by id', async () => {
+			mockModelMethodResult(
+				mockUnitModel,
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'unit1',
+				},
+				'findOne',
+			);
+
+			const result = await unitRepository.findById('orgId', 'id');
+
+			expect(result).toBeInstanceOf(UnitEntity);
+			expect(result.id).toBe('662e469a5213ce0cd9b5c473');
+			expect(result.name).toBe('unit1');
+		});
+
+		it('should throw UnitNotFoundException if unit is not found', async () => {
+			mockModelMethodResult(mockUnitModel, null, 'findOne');
+			await expect(unitRepository.findById('orgId', 'id')).rejects.toThrow(
+				UnitNotFoundException,
+			);
+		});
+	});
+
+	it('should find units by organization id', async () => {
+		mockModelMethodResults(
+			mockUnitModel,
+			[
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'unit1',
+				},
+				{
+					_id: new Types.ObjectId('662e46a16d91b65f5cfe6cbb'),
+					name: 'unit2',
+				},
+			],
+			'find',
+		);
+
+		const result = await unitRepository.findByOrg('orgId');
+
+		expect(result[0]).toBeInstanceOf(UnitEntity);
+		expect(result[0].id).toBe('662e469a5213ce0cd9b5c473');
+		expect(result[0].name).toBe('unit1');
+		expect(result[1]).toBeInstanceOf(UnitEntity);
+		expect(result[1].id).toBe('662e46a16d91b65f5cfe6cbb');
+		expect(result[1].name).toBe('unit2');
+	});
+
+	describe('findByRcsId', () => {
+		it('should find unit by RCS id', async () => {
+			mockModelMethodResult(
+				mockUnitModel,
+				{
+					_id: new Types.ObjectId('662e469a5213ce0cd9b5c473'),
+					name: 'unit1',
+				},
+				'findOne',
+			);
+
+			const result = await unitRepository.findByRcsId('orgId', 'rcsId');
+
+			expect(result).toBeInstanceOf(UnitEntity);
+			expect(result.id).toBe('662e469a5213ce0cd9b5c473');
+			expect(result.name).toBe('unit1');
+		});
+
+		it('should throw UnitNotFoundException if unit is not found', async () => {
+			mockModelMethodResult(mockUnitModel, null, 'findOne');
+			await expect(
+				unitRepository.findByRcsId('orgId', 'rcsId'),
+			).rejects.toThrow(UnitNotFoundException);
+		});
+	});
+
+	describe('updateNote', () => {
+		it('should call the updateNote method correctly', async () => {
+			const orgId = 'orgId';
+			const id = 'id';
+			const note = 'note';
+
+			await unitRepository.updateNote(orgId, id, note);
+
+			expect(mockUnitModel.updateOne).toHaveBeenCalledWith(
+				{ _id: id, orgId },
+				{ $set: { note } },
+			);
+		});
+
+		it('should return true if modifiedCount is greater than 0', async () => {
+			mockUnitModel.updateOne.mockResolvedValueOnce({
+				modifiedCount: 1,
+			} as any);
+
+			const result = await unitRepository.updateNote('orgId', 'id', 'note');
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if modifiedCount is 0', async () => {
+			mockUnitModel.updateOne.mockResolvedValueOnce({
+				modifiedCount: 0,
+			} as any);
+
+			const result = await unitRepository.updateNote('orgId', 'id', 'note');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('updateStatus', () => {
+		it('should call the updateStatus method correctly', async () => {
+			const status = new UnitStatus();
+			status.receivedAt = new Date();
+			status.source = 'someSource';
+			status.status = 1;
+
+			await unitRepository.updateStatus('orgId', 'id', status);
+
+			expect(mockUnitModel.updateOne).toHaveBeenCalledWith(
+				{
+					_id: 'id',
+					orgId: 'orgId',
+					'status.receivedAt': { $lt: status.receivedAt },
+				},
+				{ $set: { status } },
+			);
+		});
+
+		it('should return true if modifiedCount is greater than 0', async () => {
+			const status = new UnitStatus();
+			status.receivedAt = new Date();
+			status.source = 'someSource';
+			status.status = 1;
+			mockUnitModel.updateOne.mockResolvedValueOnce({
+				modifiedCount: 1,
+			} as any);
+
+			const result = await unitRepository.updateStatus('orgId', 'id', status);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if modifiedCount is 0', async () => {
+			const status = new UnitStatus();
+			status.receivedAt = new Date();
+			status.source = 'someSource';
+			status.status = 1;
+
+			mockUnitModel.updateOne.mockResolvedValueOnce({
+				modifiedCount: 0,
+			} as any);
+
+			const result = await unitRepository.updateStatus('orgId', 'id', status);
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/libs/api/unit/src/lib/infra/repository/unit.repository.ts
+++ b/libs/api/unit/src/lib/infra/repository/unit.repository.ts
@@ -1,0 +1,75 @@
+import { Mapper } from '@automapper/core';
+import { getMapperToken } from '@automapper/nestjs';
+import { Inject } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { UnitEntity, UnitStatus } from '../../core/entity/unit.entity';
+import { UnitNotFoundException } from '../../core/exception/unit-not-found.exception';
+import { UnitRepository } from '../../core/repository/unit.repository';
+import { UnitDocument } from '../schema/unit.schema';
+
+export class UnitRepositoryImpl implements UnitRepository {
+	constructor(
+		@InjectModel(UnitDocument.name)
+		private readonly unitModel: Model<UnitDocument>,
+		@Inject(getMapperToken()) private readonly mapper: Mapper,
+	) {}
+
+	async findByIds(ids: string[]): Promise<UnitEntity[]> {
+		const units = await this.unitModel
+			.find({ _id: { $in: ids } })
+			.lean()
+			.exec();
+
+		return this.mapper.mapArrayAsync(units, UnitDocument, UnitEntity);
+	}
+
+	async findById(orgId: string, id: string): Promise<UnitEntity> {
+		const unit = await this.unitModel.findOne({ _id: id, orgId }).lean().exec();
+
+		if (!unit) {
+			throw new UnitNotFoundException();
+		}
+
+		return this.mapper.mapAsync(unit, UnitDocument, UnitEntity);
+	}
+
+	async findByOrg(orgId: string): Promise<UnitEntity[]> {
+		const units = await this.unitModel.find({ orgId }).lean().exec();
+
+		return this.mapper.mapArrayAsync(units, UnitDocument, UnitEntity);
+	}
+
+	async findByRcsId(orgId: string, rcsId: string): Promise<UnitEntity> {
+		const unit = await this.unitModel.findOne({ orgId, rcsId }).lean().exec();
+
+		if (!unit) {
+			throw new UnitNotFoundException();
+		}
+
+		return this.mapper.mapAsync(unit, UnitDocument, UnitEntity);
+	}
+
+	async updateNote(orgId: string, id: string, note: string): Promise<boolean> {
+		const res = await this.unitModel.updateOne(
+			{ _id: id, orgId },
+			{ $set: { note } },
+		);
+		return res.modifiedCount > 0;
+	}
+
+	async updateStatus(
+		orgId: string,
+		id: string,
+		status: UnitStatus,
+	): Promise<boolean> {
+		// we only want to update if the new status is newer than the current one
+		const res = await this.unitModel.updateOne(
+			{ _id: id, orgId, 'status.receivedAt': { $lt: status.receivedAt } },
+			{ $set: { status } },
+		);
+
+		return res.modifiedCount > 0;
+	}
+}

--- a/libs/api/unit/src/lib/infra/schema/alert-group.schema.ts
+++ b/libs/api/unit/src/lib/infra/schema/alert-group.schema.ts
@@ -1,0 +1,21 @@
+import { AutoMap } from '@automapper/classes';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+
+import { BaseDocument } from '@kordis/api/shared';
+
+import { UnitDocument } from './unit.schema';
+
+@Schema({ timestamps: true, collection: 'alert-groups' })
+export class AlertGroupDocument extends BaseDocument {
+	@Prop()
+	@AutoMap()
+	name: string;
+
+	@Prop({ type: [Types.ObjectId], ref: 'UnitDocument' })
+	@AutoMap(() => [UnitDocument])
+	units: UnitDocument[] | Types.ObjectId[];
+}
+
+export const AlertGroupSchema =
+	SchemaFactory.createForClass(AlertGroupDocument);

--- a/libs/api/unit/src/lib/infra/schema/unit.schema.ts
+++ b/libs/api/unit/src/lib/infra/schema/unit.schema.ts
@@ -1,0 +1,75 @@
+import { AutoMap } from '@automapper/classes';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+import { BaseDocument } from '@kordis/api/shared';
+
+import { PersistentUnitStatus } from '../../core/entity/status.type';
+
+@Schema()
+export class UnitStatus {
+	@Prop({ type: Number })
+	@AutoMap(() => Number)
+	status: PersistentUnitStatus;
+
+	@Prop(() => Date)
+	@AutoMap()
+	receivedAt: Date;
+
+	@Prop()
+	@AutoMap()
+	source: string;
+}
+
+const UnitStatusSchema = SchemaFactory.createForClass(UnitStatus);
+
+@Schema()
+export class FurtherAttribute {
+	@Prop()
+	@AutoMap()
+	name: string;
+
+	@Prop()
+	@AutoMap()
+	value: string;
+}
+
+const FurtherAttributeSchema = SchemaFactory.createForClass(FurtherAttribute);
+
+@Schema({ timestamps: true, collection: 'units' })
+export class UnitDocument extends BaseDocument {
+	@Prop()
+	@AutoMap()
+	name: string;
+
+	@Prop({ default: null, type: UnitStatusSchema })
+	@AutoMap(() => UnitStatus)
+	status: UnitStatus | null;
+
+	@Prop()
+	@AutoMap()
+	note: string;
+
+	@Prop()
+	@AutoMap()
+	department: string;
+
+	@Prop()
+	@AutoMap()
+	rcsId: string;
+
+	@Prop()
+	@AutoMap()
+	callSign: string;
+
+	@Prop()
+	@AutoMap()
+	callSignAbbreviation: string;
+
+	@Prop({ type: [FurtherAttributeSchema] })
+	@AutoMap()
+	furtherAttributes: FurtherAttribute[];
+}
+
+export const UnitSchema = SchemaFactory.createForClass(UnitDocument);
+
+UnitSchema.index({ orgId: 1, rcsId: 1 }, { unique: true });

--- a/libs/api/unit/src/lib/infra/unit.module.ts
+++ b/libs/api/unit/src/lib/infra/unit.module.ts
@@ -3,7 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { UpdateUnitNoteHandler } from '../core/command/update-unit-note.command';
 import { UpdateUnitStatusHandler } from '../core/command/update-unit-status.command';
-import { GetAlertGroupsByIdHandler } from '../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupByIdHandler } from '../core/query/get-alert-group-by-id.query';
 import { GetAlertGroupsByIdsHandler } from '../core/query/get-alert-groups-by-ids.query';
 import { GetAlertGroupsByOrgHandler } from '../core/query/get-alert-groups-by.org.query';
 import { GetUnitByIdHandler } from '../core/query/get-unit-by-id.query';
@@ -51,7 +51,7 @@ import { UnitDocument, UnitSchema } from './schema/unit.schema';
 		GetUnitsByIdsHandler,
 		GetUnitByIdHandler,
 		GetAlertGroupsByIdsHandler,
-		GetAlertGroupsByIdHandler,
+		GetAlertGroupByIdHandler,
 		GetAlertGroupsByOrgHandler,
 		UpdateUnitNoteHandler,
 		UpdateUnitStatusHandler,

--- a/libs/api/unit/src/lib/infra/unit.module.ts
+++ b/libs/api/unit/src/lib/infra/unit.module.ts
@@ -1,0 +1,62 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+
+import { UpdateUnitNoteHandler } from '../core/command/update-unit-note.command';
+import { UpdateUnitStatusHandler } from '../core/command/update-unit-status.command';
+import { GetAlertGroupsByIdHandler } from '../core/query/get-alert-groups-by-id.query';
+import { GetAlertGroupsByIdsHandler } from '../core/query/get-alert-groups-by-ids.query';
+import { GetAlertGroupsByOrgHandler } from '../core/query/get-alert-groups-by.org.query';
+import { GetUnitByIdHandler } from '../core/query/get-unit-by-id.query';
+import { GetUnitByRCSIDHandler } from '../core/query/get-unit-by-rcs-id.query';
+import { GetUnitsByIdsHandler } from '../core/query/get-units-by-ids.query';
+import { GetUnitsByOrgHandler } from '../core/query/get-units-by-org.query';
+import { ALERT_GROUP_REPOSITORY } from '../core/repository/alert-group.repository';
+import { UNIT_REPOSITORY } from '../core/repository/unit.repository';
+import { AlertGroupResolver } from './controller/alert-group.resolver';
+import { UnitResolver } from './controller/unit.resolver';
+import { AlertGroupProfile } from './mapper/alert-group.mapper-profile';
+import {
+	UnitProfile,
+	UnitValueObjectProfile,
+} from './mapper/unit.mapper-profile';
+import { AlertGroupRepositoryImpl } from './repository/alert-group.repository';
+import { UnitRepositoryImpl } from './repository/unit.repository';
+import {
+	AlertGroupDocument,
+	AlertGroupSchema,
+} from './schema/alert-group.schema';
+import { UnitDocument, UnitSchema } from './schema/unit.schema';
+
+@Module({
+	imports: [
+		MongooseModule.forFeature([
+			{ name: UnitDocument.name, schema: UnitSchema },
+			{ name: AlertGroupDocument.name, schema: AlertGroupSchema },
+		]),
+	],
+	providers: [
+		{
+			provide: UNIT_REPOSITORY,
+			useClass: UnitRepositoryImpl,
+		},
+		{
+			provide: ALERT_GROUP_REPOSITORY,
+			useClass: AlertGroupRepositoryImpl,
+		},
+		UnitProfile,
+		UnitValueObjectProfile,
+		AlertGroupProfile,
+		GetUnitsByOrgHandler,
+		GetUnitByRCSIDHandler,
+		GetUnitsByIdsHandler,
+		GetUnitByIdHandler,
+		GetAlertGroupsByIdsHandler,
+		GetAlertGroupsByIdHandler,
+		GetAlertGroupsByOrgHandler,
+		UpdateUnitNoteHandler,
+		UpdateUnitStatusHandler,
+		UnitResolver,
+		AlertGroupResolver,
+	],
+})
+export class UnitModule {}

--- a/libs/api/unit/src/lib/infra/unit.view-model.ts
+++ b/libs/api/unit/src/lib/infra/unit.view-model.ts
@@ -1,0 +1,1 @@
+export { UnitEntity as UnitViewModel } from '../core/entity/unit.entity';

--- a/libs/api/unit/src/lib/sagas/status.saga.spec.ts
+++ b/libs/api/unit/src/lib/sagas/status.saga.spec.ts
@@ -1,0 +1,193 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { CqrsModule, QueryBus } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+import { lastValueFrom, of, toArray } from 'rxjs';
+
+import { NewTetraStatusEvent } from '@kordis/api/tetra';
+
+import { UpdateUnitStatusCommand } from '../core/command/update-unit-status.command';
+import { UnitNotFoundException } from '../core/exception/unit-not-found.exception';
+import { GetUnitByRCSIDQuery } from '../core/query/get-unit-by-rcs-id.query';
+import { StatusSaga } from './status.saga';
+
+describe('StatusSaga', () => {
+	let saga: StatusSaga;
+	let queryBus: DeepMocked<QueryBus>;
+	beforeEach(async () => {
+		const moduleRef = await Test.createTestingModule({
+			imports: [CqrsModule],
+			providers: [StatusSaga],
+		})
+			.overrideProvider(QueryBus)
+			.useValue(createMock<QueryBus>())
+			.compile();
+
+		saga = moduleRef.get(StatusSaga);
+		queryBus = moduleRef.get(QueryBus);
+	});
+
+	describe('tetraStatusReceived', () => {
+		it('should return commands in order by each group', async () => {
+			// we want to test that the saga processes the events in order, but still allows for parallel processing of different units
+			// thus, we will simulate the query bus returning the unit with a delay, to ensure the saga processes the events in order
+			const dateOfEvent = new Date('2024-02-05T23:13:56.825Z');
+			const grp1Res = [
+				{ id: 'unit1', ttw: 100 },
+				{ id: 'unit1', ttw: 1 },
+				{ id: 'unit1', ttw: 5 },
+			];
+			const grp2Res = [
+				{ id: 'unit2', ttw: 50 },
+				{ id: 'unit2', ttw: 10 },
+			];
+			const grp3Res = [{ id: 'unit1', ttw: 1 }];
+
+			queryBus.execute.mockImplementation(async (query) => {
+				const unitQuery = query as GetUnitByRCSIDQuery;
+
+				if (unitQuery.orgId === 'org1' && unitQuery.rcsId === 'issi1') {
+					const res = grp1Res.shift();
+					await new Promise((resolve) => setTimeout(resolve, res!.ttw));
+					return { id: res!.id };
+				} else if (unitQuery.orgId === 'org1' && unitQuery.rcsId === 'issi2') {
+					const res = grp2Res.shift();
+					await new Promise((resolve) => setTimeout(resolve, res!.ttw));
+					return { id: res!.id };
+				} else if (unitQuery.orgId === 'org2' && unitQuery.rcsId === 'issi1') {
+					const res = grp3Res.shift();
+					await new Promise((resolve) => setTimeout(resolve, res!.ttw));
+					return { id: res!.id };
+				} else {
+					throw new Error('Unknown transactional group detected');
+				}
+			});
+
+			const events = [
+				new NewTetraStatusEvent(
+					'org1',
+					'issi1',
+					1,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1
+				new NewTetraStatusEvent(
+					'org1',
+					'issi1',
+					2,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1
+				new NewTetraStatusEvent(
+					'org1',
+					'issi2',
+					3,
+					dateOfEvent,
+					'TetraControl',
+				), // group 2
+				new NewTetraStatusEvent(
+					'org1',
+					'issi1',
+					3,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1
+				new NewTetraStatusEvent(
+					'org1',
+					'issi2',
+					4,
+					dateOfEvent,
+					'TetraControl',
+				), // group 2
+				new NewTetraStatusEvent(
+					'org2',
+					'issi1',
+					4,
+					dateOfEvent,
+					'TetraControl',
+				), // group 3
+			];
+			const events$ = of(...events);
+
+			const expectedCommands = [
+				new UpdateUnitStatusCommand(
+					'org2',
+					'unit1',
+					4,
+					dateOfEvent,
+					'TetraControl',
+				), // group 3, first event
+				new UpdateUnitStatusCommand(
+					'org1',
+					'unit2',
+					3,
+					dateOfEvent,
+					'TetraControl',
+				), // group 2, first event
+				new UpdateUnitStatusCommand(
+					'org1',
+					'unit2',
+					4,
+					dateOfEvent,
+					'TetraControl',
+				), // group 2, second event
+				new UpdateUnitStatusCommand(
+					'org1',
+					'unit1',
+					1,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1, first event
+				new UpdateUnitStatusCommand(
+					'org1',
+					'unit1',
+					2,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1, second event
+				new UpdateUnitStatusCommand(
+					'org1',
+					'unit1',
+					3,
+					dateOfEvent,
+					'TetraControl',
+				), // group 1, third event
+			];
+
+			await expect(
+				lastValueFrom(saga.tetraStatusReceived(events$).pipe(toArray())),
+			).resolves.toEqual(expectedCommands);
+		});
+
+		it('should not create command if unit is not found', async () => {
+			queryBus.execute.mockRejectedValue(new UnitNotFoundException());
+
+			const events$ = of(
+				new NewTetraStatusEvent('org1', 'issi1', 1, new Date(), 'TetraControl'),
+			);
+
+			await expect(
+				lastValueFrom(saga.tetraStatusReceived(events$).pipe(toArray())),
+			).resolves.toHaveLength(0);
+		});
+
+		it('should filter status that are not storable', async () => {
+			queryBus.execute.mockResolvedValue({ id: 'unit1' });
+
+			const events$ = of(
+				new NewTetraStatusEvent('org1', 'issi1', 0, new Date(), 'TetraControl'),
+				new NewTetraStatusEvent('org1', 'issi1', 5, new Date(), 'TetraControl'),
+				new NewTetraStatusEvent(
+					'org1',
+					'issi1',
+					10,
+					new Date(),
+					'TetraControl',
+				),
+			);
+
+			await expect(
+				lastValueFrom(saga.tetraStatusReceived(events$).pipe(toArray())),
+			).resolves.toHaveLength(0);
+		});
+	});
+});

--- a/libs/api/unit/src/lib/sagas/status.saga.ts
+++ b/libs/api/unit/src/lib/sagas/status.saga.ts
@@ -1,0 +1,68 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ICommand, IEvent, QueryBus, Saga, ofType } from '@nestjs/cqrs';
+import { Observable, concatMap, filter, groupBy, mergeMap } from 'rxjs';
+
+import { KordisLogger } from '@kordis/api/observability';
+import { NewTetraStatusEvent } from '@kordis/api/tetra';
+
+import { UpdateUnitStatusCommand } from '../core/command/update-unit-status.command';
+import { ALLOWED_PERSISTENT_UNIT_STATUS } from '../core/entity/status.type';
+import { UnitEntity } from '../core/entity/unit.entity';
+import { UnitNotFoundException } from '../core/exception/unit-not-found.exception';
+import { GetUnitByRCSIDQuery } from '../core/query/get-unit-by-rcs-id.query';
+
+@Injectable()
+export class StatusSaga {
+	private readonly logger: KordisLogger = new Logger(StatusSaga.name);
+	private readonly allowedStatusForPersistentUpdate: Set<number> = new Set(
+		ALLOWED_PERSISTENT_UNIT_STATUS,
+	);
+
+	constructor(private readonly queryBus: QueryBus) {}
+
+	@Saga()
+	tetraStatusReceived = (events$: Observable<IEvent>): Observable<ICommand> =>
+		events$.pipe(
+			ofType(NewTetraStatusEvent),
+			// We only want to process status updates that are allowed to be stored in the database, 0, 5 are temporary statuses and >9 usually do not exist
+			filter((event) =>
+				this.allowedStatusForPersistentUpdate.has(event.status),
+			),
+			// We group by the organization and units issi, since we want to make sure these status updates are processed in order, while still allowing for parallel processing of different units
+			groupBy((event) => `${event.orgId}${event.issi}`),
+			mergeMap((group) =>
+				group.pipe(
+					concatMap(async (event) => {
+						let unit: UnitEntity;
+						try {
+							unit = await this.queryBus.execute<
+								GetUnitByRCSIDQuery,
+								UnitEntity
+							>(new GetUnitByRCSIDQuery(event.orgId, event.issi));
+						} catch (error) {
+							if (error instanceof UnitNotFoundException) {
+								this.logger.warn(
+									'Received status for unit that is not in the database',
+									{
+										event,
+									},
+								);
+								return null;
+							}
+
+							throw error;
+						}
+
+						return new UpdateUnitStatusCommand(
+							event.orgId,
+							unit.id,
+							event.status,
+							event.sentAt,
+							event.source,
+						);
+					}),
+				),
+			),
+			filter((command): command is UpdateUnitStatusCommand => command != null),
+		);
+}

--- a/libs/api/unit/src/lib/sagas/units-sagas.module.ts
+++ b/libs/api/unit/src/lib/sagas/units-sagas.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { StatusSaga } from './status.saga';
+
+@Module({
+	providers: [StatusSaga],
+})
+export class UnitsSagaModule {}

--- a/libs/api/unit/tsconfig.json
+++ b/libs/api/unit/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": false
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/api/unit/tsconfig.lib.json
+++ b/libs/api/unit/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"],
+		"target": "es2021",
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"strictBindCallApply": true,
+		"forceConsistentCasingInFileNames": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src/**/*.ts", "../../../reset.d.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/api/unit/tsconfig.spec.json
+++ b/libs/api/unit/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"],
+		"esModuleInterop": true
+	},
+	"include": [
+		"jest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts"
+	]
+}

--- a/tools/db/data/alert-groups.data.ts
+++ b/tools/db/data/alert-groups.data.ts
@@ -1,0 +1,30 @@
+import { Types } from 'mongoose';
+
+import { AlertGroupDocument } from '../../../libs/api/unit/src/lib/infra/schema/alert-group.schema';
+import { CollectionData } from './collection-data.model';
+
+const collectionData: CollectionData<AlertGroupDocument> = {
+	collectionName: 'alert-groups',
+	entries: [
+		{
+			_id: new Types.ObjectId('66155eb19bceefe5e63fa651'),
+			orgId: 'dff7584efe2c174eee8bae45',
+			name: 'SEG Altona',
+			units: [new Types.ObjectId('65d7d9ae8b516612650163d8')],
+		},
+		{
+			_id: new Types.ObjectId('66239459ef2a6ac579f55cce'),
+			orgId: 'dff7584efe2c174eee8bae45',
+			name: 'SEG Tauchen',
+			units: [new Types.ObjectId('65d7da8630f360f158caec53')],
+		},
+		{
+			_id: new Types.ObjectId('662394314aab59510b80e38a'),
+			orgId: 'dff7584efe2c174eee8bae45',
+			name: 'SEG Sonar (Bergedorf)',
+			units: [new Types.ObjectId('661d523ecc560fd0042fe40e')],
+		},
+	],
+};
+
+export default collectionData;

--- a/tools/db/data/units.data.ts
+++ b/tools/db/data/units.data.ts
@@ -1,0 +1,125 @@
+import { Types } from 'mongoose';
+
+import { UnitDocument } from '../../../libs/api/unit/src/lib/infra/schema/unit.schema';
+import { CollectionData } from './collection-data.model';
+
+const collectionData: CollectionData<UnitDocument> = {
+	collectionName: 'units',
+	entries: [
+		{
+			_id: new Types.ObjectId('65d7d90709cdb6f3b2082ab3'),
+			createdAt: new Date(),
+			status: null,
+			name: 'MRB Greif 5',
+			callSign: 'HH 12/42',
+			callSignAbbreviation: '1242',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG Bz Altona e.V.',
+			rcsId: 'issiGreif5',
+			furtherAttributes: [
+				{
+					name: 'MMSI',
+					value: '211397810',
+				},
+			],
+			note: 'Aktuell kein O2!',
+		},
+		{
+			_id: new Types.ObjectId('65d7d9ae8b516612650163d8'),
+			createdAt: new Date(),
+			status: {
+				status: 1,
+				source: 'TetraControl',
+				receivedAt: new Date(),
+			},
+			name: 'ATV',
+			callSign: 'HH 12/54',
+			callSignAbbreviation: '1254',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG Bz Altona e.V.',
+			rcsId: 'issiARV',
+			furtherAttributes: [
+				{
+					name: 'Sitze',
+					value: '3',
+				},
+			],
+			note: '',
+		},
+		{
+			_id: new Types.ObjectId('65d7da8630f360f158caec53'),
+			createdAt: new Date(),
+			status: {
+				status: 2,
+				source: 'TetraControl',
+				receivedAt: new Date(),
+			},
+			name: 'GW Tauchen',
+			callSign: 'HH 10/53',
+			callSignAbbreviation: '1053',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG LV Hamburg e.V.',
+			rcsId: 'issiGWTauchen',
+			furtherAttributes: [
+				{
+					name: 'Tauchgeräte',
+					value: '4',
+				},
+			],
+			note: 'Sofortige EB bei Alarmierung über Divera!',
+		},
+		{
+			_id: new Types.ObjectId('661d51d719bfd9cb73e27834'),
+			createdAt: new Date(),
+			status: {
+				status: 2,
+				source: 'TetraControl',
+				receivedAt: new Date(),
+			},
+			name: 'MRB Greif 1',
+			callSign: 'HH 12/41',
+			callSignAbbreviation: '1241',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG Bz Altona e.V.',
+			rcsId: 'issiGreif1',
+			furtherAttributes: [],
+			note: '',
+		},
+		{
+			_id: new Types.ObjectId('661d523ecc560fd0042fe40e'),
+			createdAt: new Date(),
+			status: {
+				status: 2,
+				source: 'TetraControl',
+				receivedAt: new Date(),
+			},
+			name: 'GW-Wasserrettung',
+			callSign: 'HH 13/52',
+			callSignAbbreviation: '1352',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG Bz Bergedorf e.V.',
+			rcsId: 'issiGwwr',
+			furtherAttributes: [],
+			note: '',
+		},
+		{
+			_id: new Types.ObjectId('661d52f2459197edda093912'),
+			createdAt: new Date(),
+			status: {
+				status: 2,
+				source: 'TetraControl',
+				receivedAt: new Date(),
+			},
+			name: 'MRB Greif 14',
+			callSign: 'HH 16/42',
+			callSignAbbreviation: '1642',
+			orgId: 'dff7584efe2c174eee8bae45',
+			department: 'DLRG Bz Harburg e.V.',
+			rcsId: 'issiGreif14',
+			furtherAttributes: [],
+			note: '',
+		},
+	],
+};
+
+export default collectionData;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
 			"@kordis/api/shared": ["libs/api/shared/src/index.ts"],
 			"@kordis/api/test-helpers": ["libs/api/test-helpers/src/index.ts"],
 			"@kordis/api/tetra": ["libs/api/tetra/src/index.ts"],
+			"@kordis/api/unit": ["libs/api/unit/src/index.ts"],
 			"@kordis/api/user": ["libs/api/user/src/index.ts"],
 			"@kordis/shared/model": ["libs/shared/model/src/index.ts"],
 			"@kordis/shared/test-helpers": ["libs/shared/test-helpers/src/index.ts"],


### PR DESCRIPTION
# Description

This introduces the backend for units and alert groups, which is mostly just base data management. Furthermore, it introduces a saga, that converts Tetra status events into update unit status commands.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
- [x] I have included the `reset.d.ts` in the `tsconfig.lib.json` 

<!-- Uncomment the following lines if you introduced a new SPA library -->
<!--
- [ ] I have included the `reset.d.ts` in the `tsconfig.lib.json`
- [ ] I have extended the `.eslintrc.json` with `.eslintrc.angular.json`
-->
