### PR TITLE
refactor: remove document extension from base document

### DIFF
--- a/libs/api/organization/src/lib/infra/repository/organization.respository.spec.ts
+++ b/libs/api/organization/src/lib/infra/repository/organization.respository.spec.ts
@@ -3,7 +3,7 @@ import { AutomapperModule } from '@automapper/nestjs';
 import { createMock } from '@golevelup/ts-jest';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test } from '@nestjs/testing';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 
 import {
 	Coordinate,
@@ -74,7 +74,7 @@ describe('ImplOrganizationRepository', () => {
 
 	describe('findById', () => {
 		it('should return mapped organization entity', async () => {
-			const orgId = 'org-id';
+			const orgId = new Types.ObjectId().toString();
 			const orgName = 'org-name';
 			const geoSettings = {
 				bbox: {
@@ -90,7 +90,7 @@ describe('ImplOrganizationRepository', () => {
 			const updatedAt = new Date();
 
 			const orgDoc: Mutable<OrganizationDocument> = {} as OrganizationDocument;
-			orgDoc._id = orgId;
+			orgDoc._id = new Types.ObjectId(orgId);
 			orgDoc.orgId = orgId;
 			orgDoc.name = orgName;
 			orgDoc.geoSettings = geoSettings;

--- a/libs/api/organization/src/lib/infra/schema/organization.schema.ts
+++ b/libs/api/organization/src/lib/infra/schema/organization.schema.ts
@@ -39,7 +39,7 @@ export const OrganizationSchema =
 
 OrganizationSchema.pre('save', function (next) {
 	if (this.isNew) {
-		this.orgId = this._id;
+		this.orgId = this._id.toString();
 	}
 	next();
 });

--- a/libs/api/shared/src/lib/models/base-document.model.ts
+++ b/libs/api/shared/src/lib/models/base-document.model.ts
@@ -1,10 +1,13 @@
 import { AutoMap } from '@automapper/classes';
 import { Prop } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 import { BaseModel } from './base-entity.model';
 
-export class BaseDocument extends Document implements BaseModel {
+export class BaseDocument implements BaseModel, Pick<Document, '_id'> {
+	@AutoMap()
+	_id?: Types.ObjectId;
+
 	@Prop({ index: true })
 	@AutoMap()
 	orgId: string;
@@ -16,16 +19,4 @@ export class BaseDocument extends Document implements BaseModel {
 	@Prop()
 	@AutoMap()
 	updatedAt: Date;
-
-	constructor() {
-		super();
-		this.schema.pre('save', function (next) {
-			const savedAt = new Date();
-			if (this.isNew) {
-				this.createdAt = savedAt;
-			}
-			this.updatedAt = savedAt;
-			next();
-		});
-	}
 }

--- a/libs/api/shared/src/lib/models/base-document.model.ts
+++ b/libs/api/shared/src/lib/models/base-document.model.ts
@@ -5,7 +5,6 @@ import { Document, Types } from 'mongoose';
 import { BaseModel } from './base-entity.model';
 
 export class BaseDocument implements BaseModel, Pick<Document, '_id'> {
-	@AutoMap()
 	_id?: Types.ObjectId;
 
 	@Prop({ index: true })

--- a/libs/api/shared/src/lib/models/base-entity.model.ts
+++ b/libs/api/shared/src/lib/models/base-entity.model.ts
@@ -13,16 +13,18 @@ export interface BaseModel {
 @ObjectType({ isAbstract: true })
 export class BaseEntityModel extends Validatable implements BaseModel {
 	@Field(() => ID)
-	@AutoMap()
 	readonly id: string;
+
 	@IsString()
 	@IsNotEmpty()
 	@Field()
 	@AutoMap()
 	orgId: string;
+
 	@Field()
 	@AutoMap()
 	readonly createdAt: Date = new Date();
+
 	@Field({ nullable: true })
 	@AutoMap()
 	readonly updatedAt: Date;

--- a/libs/api/shared/src/lib/models/base-model.mapper-profile.ts
+++ b/libs/api/shared/src/lib/models/base-model.mapper-profile.ts
@@ -25,7 +25,7 @@ export class BaseModelProfile extends AutomapperProfile {
 				BaseEntityModel,
 				forMember(
 					(d) => d.id,
-					mapFrom((s) => s._id.toString()),
+					mapFrom((s) => s._id?.toString()),
 				),
 			);
 		};

--- a/libs/api/shared/src/lib/models/base.mapper-profile.ts
+++ b/libs/api/shared/src/lib/models/base.mapper-profile.ts
@@ -1,4 +1,10 @@
-import { MappingConfiguration, extend } from '@automapper/core';
+import {
+	MappingConfiguration,
+	createMap,
+	extend,
+	forMember,
+	mapFrom,
+} from '@automapper/core';
 import { AutomapperProfile } from '@automapper/nestjs';
 
 import { BaseDocument } from './base-document.model';
@@ -6,6 +12,18 @@ import { BaseEntityModel } from './base-entity.model';
 
 export abstract class BaseMapperProfile extends AutomapperProfile {
 	protected override get mappingConfigurations(): MappingConfiguration[] {
-		return [extend(BaseDocument, BaseEntityModel)];
+		return [
+			extend(
+				createMap(
+					this.mapper,
+					BaseDocument,
+					BaseEntityModel,
+					forMember(
+						(d) => d.id,
+						mapFrom((s) => s._id?.toString()),
+					),
+				),
+			),
+		];
 	}
 }


### PR DESCRIPTION
# Description

This PR removes the Mongoose `Document` extension from `BaseDocument` since this is [discouraged](https://mongoosejs.com/docs/6.x/docs/typescript.html#using-extends-document) by Mongoose and leads to a lot of issues especially instantiating a document class. Additionally, most Mongoose methods like `create` or `update` return an instance of the updated entity wrapped inside a `Document` class. This way, the functionality of the `Document` class still remains.

Since the current implementation of `createdAt` does not work without extending `Document` anymore, the implementation is removed. However, the functionality can be kept by adding 
```ts
@Schema({
	timestamps: true,
	...
})
```
to the schemas.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
