### PR TITLE
chore(api): register data loaders in feature modules

### DIFF
--- a/libs/api/deployment/src/lib/infra/controller/deployment.resolver.ts
+++ b/libs/api/deployment/src/lib/infra/controller/deployment.resolver.ts
@@ -13,7 +13,12 @@ import {
 
 import { RequestUser } from '@kordis/api/auth';
 import { DataLoaderContextProvider } from '@kordis/api/shared';
-import { AlertGroupViewModel, UnitViewModel } from '@kordis/api/unit';
+import {
+	ALERT_GROUPS_DATA_LOADER,
+	AlertGroupViewModel,
+	UNITS_DATA_LOADER,
+	UnitViewModel,
+} from '@kordis/api/unit';
 import { AuthUser } from '@kordis/shared/model';
 
 import {
@@ -24,8 +29,6 @@ import { RescueStationDeploymentEntity } from '../../core/entity/rescue-station-
 import { GetDeploymentsQuery } from '../../core/query/get-deployments.query';
 import { GetUnassignedEntitiesQuery } from '../../core/query/get-unassigned-entities.query';
 import { RescueStationEntityDTO } from '../../core/repository/rescue-station-deployment.repository';
-import { ALERT_GROUPS_DATA_LOADER } from '../data-loader/alert-groups.data-loader';
-import { UNITS_DATA_LOADER } from '../data-loader/units.data-loader';
 import {
 	DeploymentAssignment,
 	RescueStationDeploymentViewModel,

--- a/libs/api/deployment/src/lib/infra/deployment.module.ts
+++ b/libs/api/deployment/src/lib/infra/deployment.module.ts
@@ -24,8 +24,6 @@ import {
 	DeploymentUnitResolver,
 	RescueStationDeploymentDefaultUnitsResolver,
 } from './controller/deployment.resolver';
-import { AlertGroupsDataLoader } from './data-loader/alert-groups.data-loader';
-import { UnitsDataLoader } from './data-loader/units.data-loader';
 import { DeploymentAggregateProfile } from './mapper/deployment-aggregate.mapper-profile';
 import { DeploymentAssignmentProfile } from './mapper/deployment-assignment.mapper-profile';
 import {
@@ -88,7 +86,6 @@ const RESOLVERS = [
 	AlertGroupAssignmentResolver,
 	RescueStationDeploymentDefaultUnitsResolver,
 ];
-const DATA_LOADERS = [UnitsDataLoader, AlertGroupsDataLoader];
 const MAPPER_PROFILES = [
 	DeploymentAggregateProfile,
 	DeploymentAssignmentProfile,
@@ -138,7 +135,6 @@ const DOMAIN_SERVICES = [
 		...REPOSITORIES,
 		...CQRS_HANDLERS,
 		...RESOLVERS,
-		...DATA_LOADERS,
 		...MAPPER_PROFILES,
 		...DOMAIN_SERVICES,
 	],

--- a/libs/api/unit/src/index.ts
+++ b/libs/api/unit/src/index.ts
@@ -3,4 +3,8 @@ export * from './lib/sagas/units-sagas.module';
 export * from './lib/infra/unit.view-model';
 export * from './lib/infra/alert-group.view-model';
 export { GetUnitsByIdsQuery } from './lib/core/query/get-units-by-ids.query';
+export { GetUnitByIdQuery } from './lib/core/query/get-unit-by-id.query';
 export { GetAlertGroupsByIdsQuery } from './lib/core/query/get-alert-groups-by-ids.query';
+export { UnitStatusUpdatedEvent } from './lib/core/event/unit-status-updated.event';
+export { UNITS_DATA_LOADER } from './lib/data-loader/units.data-loader';
+export { ALERT_GROUPS_DATA_LOADER } from './lib/data-loader/alert-groups.data-loader';

--- a/libs/api/unit/src/lib/data-loader/alert-groups.data-loader.spec.ts
+++ b/libs/api/unit/src/lib/data-loader/alert-groups.data-loader.spec.ts
@@ -3,8 +3,8 @@ import { QueryBus } from '@nestjs/cqrs';
 import DataLoader from 'dataloader';
 
 import { DataLoaderContainer } from '@kordis/api/shared';
-import { GetAlertGroupsByIdsQuery } from '@kordis/api/unit';
 
+import { GetAlertGroupsByIdsQuery } from '../core/query/get-alert-groups-by-ids.query';
 import {
 	ALERT_GROUPS_DATA_LOADER,
 	AlertGroupsDataLoader,

--- a/libs/api/unit/src/lib/data-loader/alert-groups.data-loader.ts
+++ b/libs/api/unit/src/lib/data-loader/alert-groups.data-loader.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 
 import { DataLoaderContainer } from '@kordis/api/shared';
-import { GetAlertGroupsByIdsQuery } from '@kordis/api/unit';
+
+import { GetAlertGroupsByIdsQuery } from '../core/query/get-alert-groups-by-ids.query';
 
 export const ALERT_GROUPS_DATA_LOADER = Symbol('ALERT_GROUPS_DATA_LOADER');
 

--- a/libs/api/unit/src/lib/data-loader/units.data-loader.spec.ts
+++ b/libs/api/unit/src/lib/data-loader/units.data-loader.spec.ts
@@ -3,8 +3,8 @@ import { QueryBus } from '@nestjs/cqrs';
 import DataLoader from 'dataloader';
 
 import { DataLoaderContainer } from '@kordis/api/shared';
-import { GetUnitsByIdsQuery } from '@kordis/api/unit';
 
+import { GetUnitsByIdsQuery } from '../core/query/get-units-by-ids.query';
 import { UNITS_DATA_LOADER, UnitsDataLoader } from './units.data-loader';
 
 describe('UnitsDataLoader', () => {

--- a/libs/api/unit/src/lib/data-loader/units.data-loader.ts
+++ b/libs/api/unit/src/lib/data-loader/units.data-loader.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 
 import { DataLoaderContainer } from '@kordis/api/shared';
-import { GetUnitsByIdsQuery } from '@kordis/api/unit';
+
+import { GetUnitsByIdsQuery } from '../core/query/get-units-by-ids.query';
 
 export const UNITS_DATA_LOADER = Symbol('UNITS_DATA_LOADER');
 

--- a/libs/api/unit/src/lib/infra/unit.module.ts
+++ b/libs/api/unit/src/lib/infra/unit.module.ts
@@ -12,6 +12,8 @@ import { GetUnitsByIdsHandler } from '../core/query/get-units-by-ids.query';
 import { GetUnitsByOrgHandler } from '../core/query/get-units-by-org.query';
 import { ALERT_GROUP_REPOSITORY } from '../core/repository/alert-group.repository';
 import { UNIT_REPOSITORY } from '../core/repository/unit.repository';
+import { AlertGroupsDataLoader } from '../data-loader/alert-groups.data-loader';
+import { UnitsDataLoader } from '../data-loader/units.data-loader';
 import { AlertGroupResolver } from './controller/alert-group.resolver';
 import { UnitResolver } from './controller/unit.resolver';
 import { AlertGroupProfile } from './mapper/alert-group.mapper-profile';
@@ -57,6 +59,8 @@ import { UnitDocument, UnitSchema } from './schema/unit.schema';
 		UpdateUnitStatusHandler,
 		UnitResolver,
 		AlertGroupResolver,
+		UnitsDataLoader,
+		AlertGroupsDataLoader,
 	],
 })
 export class UnitModule {}


### PR DESCRIPTION
As discussed, we will register the data loaders in their respective feature modules and export the register symbol, which can be reused from anywhere in the API.