### PR TITLE
chore(spa): add antd variables via project styles

### DIFF
--- a/apps/spa/project.json
+++ b/apps/spa/project.json
@@ -22,6 +22,7 @@
 				],
 				"styles": [
 					"./node_modules/ng-zorro-antd/ng-zorro-antd.min.css",
+					"./node_modules/ng-zorro-antd/ng-zorro-antd.variable.min.css",
 					"apps/spa/src/styles.css"
 				],
 				"scripts": [],

--- a/libs/spa/view/dashboard/src/lib/dashboard.component.css
+++ b/libs/spa/view/dashboard/src/lib/dashboard.component.css
@@ -1,5 +1,3 @@
-@import '../../../../../../node_modules/ng-zorro-antd/ng-zorro-antd.variable.min.css';
-
 nz-layout {
 	--header-size: 64px;
 


### PR DESCRIPTION
Moves the import of antd css variables from the dashboard component stylesheet into the project styles, so we can use them globally without the need to import them everytime.