### PR TITLE
feat(api-shared): retain entity order for queries

### DIFF
--- a/libs/api/shared/src/index.ts
+++ b/libs/api/shared/src/index.ts
@@ -1,18 +1,19 @@
-export * from './lib/models/request.model';
-export * from './lib/models/base-entity.model';
-export * from './lib/models/base-document.model';
-export * from './lib/models/validatable.model';
-export * from './lib/models/coordinate.model';
-export * from './lib/models/base.mapper-profile';
+export * from './lib/exceptions';
 export * from './lib/kernel/graphql';
 export * from './lib/kernel/mongodb';
-export * from './lib/kernel/shared-kernel.module';
-export * from './lib/exceptions';
+export * from './lib/kernel/service/retain-order.mutator';
 export {
-	UnitOfWorkService,
 	DbSessionProvider,
 	UNIT_OF_WORK_SERVICE,
 	UnitOfWork,
+	UnitOfWorkService,
 	runDbOperation,
 } from './lib/kernel/service/unit-of-work.service';
+export * from './lib/kernel/shared-kernel.module';
+export * from './lib/models/base-document.model';
+export * from './lib/models/base-entity.model';
 export { BaseModelProfile } from './lib/models/base-model.mapper-profile';
+export * from './lib/models/base.mapper-profile';
+export * from './lib/models/coordinate.model';
+export * from './lib/models/request.model';
+export * from './lib/models/validatable.model';

--- a/libs/api/shared/src/lib/kernel/service/retain-order.mutator.spec.ts
+++ b/libs/api/shared/src/lib/kernel/service/retain-order.mutator.spec.ts
@@ -1,0 +1,38 @@
+import { RetainOrderMutator } from './retain-order.mutator';
+
+describe('RetainOrderMutator', () => {
+	const mutator = new RetainOrderMutator('TestEntites');
+
+	it('should retain id order if enabled in options', async () => {
+		const result = mutator.retainOrderIfEnabled(
+			{ retainOrder: true },
+			['1', '2'],
+			[{ id: '2' }, { id: '1' }],
+		);
+
+		expect(result).toEqual([{ id: '1' }, { id: '2' }]);
+	});
+
+	it('should not retain id order if disabled in options', async () => {
+		const result = mutator.retainOrderIfEnabled(
+			{ retainOrder: false },
+			['1', '2'],
+			[{ id: '2' }, { id: '1' }],
+		);
+
+		expect(result).toEqual([{ id: '2' }, { id: '1' }]);
+	});
+
+	it('should sort by id order', async () => {
+		const result = mutator.sortByIdOrder(
+			['1', '2'],
+			[{ id: '2' }, { id: '1' }],
+		);
+
+		expect(result).toEqual([{ id: '1' }, { id: '2' }]);
+	});
+
+	it('should throw error on missing entitiy', async () => {
+		expect(() => mutator.sortByIdOrder(['1', '2'], [{ id: '1' }])).toThrow();
+	});
+});

--- a/libs/api/shared/src/lib/kernel/service/retain-order.mutator.ts
+++ b/libs/api/shared/src/lib/kernel/service/retain-order.mutator.ts
@@ -1,0 +1,43 @@
+export interface RetainOrderOptions {
+	retainOrder: boolean;
+}
+
+export class RetainOrderMutator {
+	constructor(private readonly entityType: string) {}
+
+	public retainOrderIfEnabled<T extends { id: string }>(
+		{ retainOrder }: RetainOrderOptions,
+		ids: string[],
+		entities: T[],
+	): T[] {
+		if (retainOrder) {
+			return this.sortByIdOrder(ids, entities);
+		}
+		return entities;
+	}
+
+	public sortByIdOrder<T extends { id: string }>(
+		ids: string[],
+		entities: T[],
+	): T[] {
+		const orderedUnits = ids.map((id) =>
+			entities.find((unit) => unit.id === id),
+		);
+		this.assertNoMissingEntities(ids, orderedUnits);
+		return orderedUnits;
+	}
+
+	private assertNoMissingEntities<T extends { id: string }>(
+		ids: string[],
+		entities: (T | undefined)[],
+	): asserts entities is T[] {
+		if (entities.includes(undefined)) {
+			const missingIds = ids.filter(
+				(id) => entities.find((entity) => entity?.id === id) === undefined,
+			);
+			throw new Error(
+				`Missing ${this.entityType} for ids: ${missingIds.join(',')}`,
+			);
+		}
+	}
+}

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.spec.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.spec.ts
@@ -1,11 +1,15 @@
 import { Test } from '@nestjs/testing';
+import { plainToClass, plainToInstance } from 'class-transformer';
 
 import { AlertGroupEntity } from '../entity/alert-group.entity';
 import {
 	ALERT_GROUP_REPOSITORY,
 	AlertGroupRepository,
 } from '../repository/alert-group.repository';
-import { GetAlertGroupsByIdsHandler } from './get-alert-groups-by-ids.query';
+import {
+	GetAlertGroupsByIdsHandler,
+	GetAlertGroupsByIdsQuery,
+} from './get-alert-groups-by-ids.query';
 
 describe('GetAlertGroupsByIdsHandler', () => {
 	let getAlertGroupsByIdsHandler: GetAlertGroupsByIdsHandler;
@@ -33,15 +37,13 @@ describe('GetAlertGroupsByIdsHandler', () => {
 	});
 
 	it('should return alert groups by ids', async () => {
-		const entity1 = new AlertGroupEntity();
-		entity1.name = 'Alert Group 1';
-		const entity2 = new AlertGroupEntity();
-		entity2.name = 'Alert Group 2';
+		const entity1 = plainToInstance(AlertGroupEntity, { id: '1' });
+		const entity2 = plainToInstance(AlertGroupEntity, { id: '2' });
 		mockAlertGroupRepository.findByIds.mockResolvedValue([entity1, entity2]);
 
-		const result = await getAlertGroupsByIdsHandler.execute({
-			ids: ['1', '2'],
-		});
+		const result = await getAlertGroupsByIdsHandler.execute(
+			new GetAlertGroupsByIdsQuery(['1', '2'], { retainOrder: true }),
+		);
 
 		expect(result).toEqual([entity1, entity2]);
 		expect(mockAlertGroupRepository.findByIds).toHaveBeenCalledWith(['1', '2']);

--- a/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-alert-groups-by-ids.query.ts
@@ -1,6 +1,8 @@
 import { Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
+import { RetainOrderMutator, RetainOrderOptions } from '@kordis/api/shared';
+
 import { AlertGroupEntity } from '../entity/alert-group.entity';
 import {
 	ALERT_GROUP_REPOSITORY,
@@ -8,13 +10,18 @@ import {
 } from '../repository/alert-group.repository';
 
 export class GetAlertGroupsByIdsQuery {
-	constructor(readonly ids: string[]) {}
+	constructor(
+		readonly ids: string[],
+		readonly options: RetainOrderOptions = { retainOrder: false },
+	) {}
 }
 
 @QueryHandler(GetAlertGroupsByIdsQuery)
 export class GetAlertGroupsByIdsHandler
 	implements IQueryHandler<GetAlertGroupsByIdsQuery>
 {
+	private readonly mutator = new RetainOrderMutator('alert groups');
+
 	constructor(
 		@Inject(ALERT_GROUP_REPOSITORY)
 		private readonly repository: AlertGroupRepository,
@@ -22,7 +29,12 @@ export class GetAlertGroupsByIdsHandler
 
 	async execute({
 		ids,
+		options,
 	}: GetAlertGroupsByIdsQuery): Promise<AlertGroupEntity[]> {
-		return this.repository.findByIds(ids);
+		let alertGroups = await this.repository.findByIds(ids);
+
+		alertGroups = this.mutator.retainOrderIfEnabled(options, ids, alertGroups);
+
+		return alertGroups;
 	}
 }

--- a/libs/api/unit/src/lib/core/query/get-units-by-ids.query.ts
+++ b/libs/api/unit/src/lib/core/query/get-units-by-ids.query.ts
@@ -1,21 +1,32 @@
 import { Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
+import { RetainOrderMutator, RetainOrderOptions } from '@kordis/api/shared';
+
 import { UnitEntity } from '../entity/unit.entity';
 import { UNIT_REPOSITORY, UnitRepository } from '../repository/unit.repository';
 
 export class GetUnitsByIdsQuery {
-	constructor(readonly ids: string[]) {}
+	constructor(
+		readonly ids: string[],
+		readonly options: RetainOrderOptions = { retainOrder: false },
+	) {}
 }
 
 @QueryHandler(GetUnitsByIdsQuery)
 export class GetUnitsByIdsHandler implements IQueryHandler<GetUnitsByIdsQuery> {
+	private readonly mutator = new RetainOrderMutator('units');
+
 	constructor(
 		@Inject(UNIT_REPOSITORY)
 		private readonly repository: UnitRepository,
 	) {}
 
-	async execute({ ids }: GetUnitsByIdsQuery): Promise<UnitEntity[]> {
-		return this.repository.findByIds(ids);
+	async execute({ ids, options }: GetUnitsByIdsQuery): Promise<UnitEntity[]> {
+		let units = await this.repository.findByIds(ids);
+
+		units = this.mutator.retainOrderIfEnabled(options, ids, units);
+
+		return units;
 	}
 }

--- a/libs/api/unit/src/lib/data-loader/units.data-loader.spec.ts
+++ b/libs/api/unit/src/lib/data-loader/units.data-loader.spec.ts
@@ -32,7 +32,7 @@ describe('UnitsDataLoader', () => {
 		await loader.loadMany(unitIds);
 
 		expect(queryBusMock.execute).toHaveBeenCalledWith(
-			new GetUnitsByIdsQuery(unitIds),
+			new GetUnitsByIdsQuery(unitIds, { retainOrder: true }),
 		);
 	});
 });

--- a/libs/api/unit/src/lib/data-loader/units.data-loader.ts
+++ b/libs/api/unit/src/lib/data-loader/units.data-loader.ts
@@ -13,7 +13,9 @@ export class UnitsDataLoader {
 		loaderContainer.registerLoadingFunction(
 			UNITS_DATA_LOADER,
 			async (unitIds: readonly string[]) =>
-				bus.execute(new GetUnitsByIdsQuery(unitIds as string[])),
+				bus.execute(
+					new GetUnitsByIdsQuery(unitIds as string[], { retainOrder: true }),
+				),
 		);
 	}
 }


### PR DESCRIPTION
Add a mutator for ensuring the entites fetched are returned in the exact order the ids where provided. This is especially important to the data loaders expecting this behavior for batched fetches.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
