### PR TITLE
chore: distribute test protocol entries among last 7 days

### DIFF
--- a/tools/db/data/protocol-entries.data.ts
+++ b/tools/db/data/protocol-entries.data.ts
@@ -92,6 +92,12 @@ const getRescueStationMessagePayload = (
 	} satisfies RescueStationMessagePayload;
 };
 
+const getRandomDateFromLastSevenDays = () => {
+	const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000;
+	const offset = Math.round(Math.random() * sevenDaysInMs);
+	return new Date(Date.now() - offset);
+};
+
 const collectionData = {
 	collectionName: 'protocol-entries',
 	entries: [
@@ -111,7 +117,7 @@ const collectionData = {
 				unitId: getUnitIdAsStringByName('ATV'),
 			},
 			searchableText: 'Test',
-			time: new Date(),
+			time: getRandomDateFromLastSevenDays(),
 			type: ProtocolEntryType.COMMUNICATION_MESSAGE_ENTRY,
 			orgId: getOrganizationIdAsStringByName('Test Organisation'),
 		} satisfies CommunicationMessageDocument,
@@ -136,7 +142,7 @@ const collectionData = {
 			},
 			searchableText:
 				'anmeldung rettungswache DLRG Einsatzzentrale HH HH 10/0 stärke 1/2/3/6 MRB Greif 5, ATV',
-			time: new Date(),
+			time: getRandomDateFromLastSevenDays(),
 			type: ProtocolEntryType.RESCUE_STATION_SIGN_ON_ENTRY,
 			orgId: getOrganizationIdAsStringByName('Test Organisation'),
 		} satisfies RescueStationSignOnMessageDocument,
@@ -162,7 +168,7 @@ const collectionData = {
 			},
 			searchableText:
 				'nachmeldung rettungswache DLRG Einsatzzentrale HH HH 10/0 stärke 1/3/6/10 SEG Altona MRB Greif 5',
-			time: new Date(),
+			time: getRandomDateFromLastSevenDays(),
 			type: ProtocolEntryType.RESCUE_STATION_UPDATE_ENTRY,
 			orgId: getOrganizationIdAsStringByName('Test Organisation'),
 		} satisfies RescueStationUpdateMessageDocument,
@@ -183,7 +189,7 @@ const collectionData = {
 			},
 			searchableText:
 				'ausmeldung rettungswache DLRG Einsatzzentrale HH HH 10/0',
-			time: new Date(),
+			time: getRandomDateFromLastSevenDays(),
 			type: ProtocolEntryType.RESCUE_STATION_SIGN_OFF_ENTRY,
 			orgId: getOrganizationIdAsStringByName('Test Organisation'),
 		} satisfies RescueStationSignOffMessageDocument,


### PR DESCRIPTION
# Description

The changes distribute the protocol entries among the last 7 days to enable better UI representation and avoid a bug which occurs whenever any two protocol entries are created the exact same millisecond.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
