### PR TITLE
style: add base spacing

### DIFF
--- a/apps/spa/src/styles.css
+++ b/apps/spa/src/styles.css
@@ -1,1 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+
+:root {
+	--base-spacing: 8px;
+}

--- a/libs/spa/core/auth/src/lib/components/dev-login.component.ts
+++ b/libs/spa/core/auth/src/lib/components/dev-login.component.ts
@@ -2,7 +2,10 @@ import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { NzButtonComponent } from 'ng-zorro-antd/button';
+import { NzDividerModule } from 'ng-zorro-antd/divider';
+import { NzFormModule } from 'ng-zorro-antd/form';
 import { NzInputDirective } from 'ng-zorro-antd/input';
+import { NzInputModule } from 'ng-zorro-antd/input';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 
 import { AuthUser, Role } from '@kordis/shared/model';
@@ -18,20 +21,21 @@ import { DevAuthService } from '../services/dev-auth.service';
 		`
 			.container {
 				max-width: 500px;
-				padding: 20px;
-
-				> div {
-					display: flex;
-					gap: 5px;
-				}
+				margin: 0 auto;
+				height: 100%;
+				padding: calc(2 * var(--base-spacing));
+				display: flex;
+				justify-content: center;
+				flex-direction: column;
+				gap: var(--base-spacing);
 
 				> form {
 					display: flex;
-					margin-top: 1.25rem;
 					flex-direction: column;
 
-					> button {
-						margin-top: 0.5rem;
+					button {
+						margin-top: var(--base-spacing);
+						width: 100%;
 					}
 				}
 			}
@@ -39,47 +43,92 @@ import { DevAuthService } from '../services/dev-auth.service';
 	],
 	template: `
 		<div class="container">
-			<div>
-				@for (username of usernames; track i; let i = $index) {
-					<button
-						nz-button
-						(click)="loginAsTestuser(i)"
-						[attr.data-username]="username"
-					>
-						Login as <b> {{ username }}</b>
-					</button>
-				}
-			</div>
-			<form [formGroup]="customClaimsForm" (ngSubmit)="loginWithCustomClaims()">
-				<label for="id">ID</label>
-				<input nz-input id="id" type="text" formControlName="id" />
-				<label for="orgId">Organization ID</label>
-				<input
-					nz-input
-					id="orgId"
-					type="text"
-					formControlName="organizationId"
-				/>
-				<label for="firstName">First name</label>
-				<input
-					nz-input
-					id="firstName"
-					type="text"
-					formControlName="firstName"
-				/>
-				<label for="lastName">Last name</label>
-				<input nz-input id="lastName" type="text" formControlName="lastName" />
-				<label for="email">Email</label>
-				<input nz-input id="email" type="text" formControlName="email" />
-				<label>Role</label>
-				<nz-select formControlName="role">
-					<nz-option nzValue="user" nzLabel="User" />
-					<nz-option nzValue="admin" nzLabel="Admin" />
-					<nz-option nzValue="organization_admin" nzLabel="Org Admin" />
-				</nz-select>
-				<button nz-button nzSize="large" nzType="primary" type="submit">
-					Login as Custom user
+			@for (username of usernames; track i; let i = $index) {
+				<button
+					nz-button
+					(click)="loginAsTestuser(i)"
+					[attr.data-username]="username"
+				>
+					Login as <b> {{ username }}</b>
 				</button>
+			}
+			<nz-divider />
+			<form
+				[formGroup]="customClaimsForm"
+				(ngSubmit)="loginWithCustomClaims()"
+				nzForm
+			>
+				<nz-form-item>
+					<nz-form-control>
+						<input
+							nz-input
+							name="id"
+							type="text"
+							formControlName="id"
+							placeholder="ID"
+						/>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<input
+							nz-input
+							name="organizationId"
+							type="text"
+							formControlName="organizationId"
+							placeholder="Organization ID"
+						/>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<input
+							nz-input
+							name="firstName"
+							type="text"
+							formControlName="firstName"
+							placeholder="First name"
+						/>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<input
+							nz-input
+							name="lastName"
+							type="text"
+							formControlName="lastName"
+							placeholder="Last name"
+						/>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<input
+							nz-input
+							name="email"
+							type="text"
+							formControlName="email"
+							placeholder="Email"
+						/>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<nz-select formControlName="role">
+							<nz-option nzValue="user" nzLabel="User" />
+							<nz-option nzValue="admin" nzLabel="Admin" />
+							<nz-option nzValue="organization_admin" nzLabel="Org Admin" />
+						</nz-select>
+					</nz-form-control>
+				</nz-form-item>
+				<nz-form-item>
+					<nz-form-control>
+						<button nz-button nzType="primary" type="submit">
+							Login as Custom user
+						</button>
+					</nz-form-control>
+				</nz-form-item>
 			</form>
 		</div>
 	`,
@@ -89,6 +138,9 @@ import { DevAuthService } from '../services/dev-auth.service';
 		NzInputDirective,
 		NzButtonComponent,
 		NzSelectModule,
+		NzDividerModule,
+		NzFormModule,
+		NzInputModule,
 	],
 })
 export class DevLoginComponent {

--- a/libs/spa/core/auth/src/lib/components/dev-login.component.ts
+++ b/libs/spa/core/auth/src/lib/components/dev-login.component.ts
@@ -4,7 +4,6 @@ import { Router } from '@angular/router';
 import { NzButtonComponent } from 'ng-zorro-antd/button';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { NzFormModule } from 'ng-zorro-antd/form';
-import { NzInputDirective } from 'ng-zorro-antd/input';
 import { NzInputModule } from 'ng-zorro-antd/input';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 
@@ -135,7 +134,6 @@ import { DevAuthService } from '../services/dev-auth.service';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	imports: [
 		ReactiveFormsModule,
-		NzInputDirective,
 		NzButtonComponent,
 		NzSelectModule,
 		NzDividerModule,

--- a/libs/spa/view/auth/src/lib/auth.component.css
+++ b/libs/spa/view/auth/src/lib/auth.component.css
@@ -5,25 +5,25 @@ nz-content {
 
 .login-form {
 	display: flex;
-	padding: 3rem 1rem;
+	padding: calc(6 * var(--base-spacing)) calc(2 * var(--base-spacing));
 	flex-direction: column;
 	flex: 1 1 0;
 	justify-content: center;
 
 	@media (min-width: 640px) {
-		padding-left: 8rem;
-		padding-right: 8rem;
+		padding-left: calc(16 * var(--base-spacing));
+		padding-right: calc(16 * var(--base-spacing));
 	}
 
 	@media (min-width: 1024px) {
-		padding-left: 5rem;
-		padding-right: 5rem;
+		padding-left: calc(10 * var(--base-spacing));
+		padding-right: calc(10 * var(--base-spacing));
 		flex: none;
 		width: 500px;
 	}
 
 	.header {
-		margin-bottom: 5rem;
+		margin-bottom: calc(10 * var(--base-spacing));
 
 		span {
 			font-size: 1rem;

--- a/libs/spa/view/dashboard/src/lib/dashboard.component.css
+++ b/libs/spa/view/dashboard/src/lib/dashboard.component.css
@@ -19,7 +19,7 @@ nz-layout {
 
 	nz-content {
 		display: grid;
-		grid-gap: 8px;
+		grid-gap: var(--base-spacing);
 		grid-template-areas:
 			'protocol operations'
 			'deployments deployments';
@@ -27,7 +27,7 @@ nz-layout {
 		grid-template-rows: minmax(0, 3fr) minmax(0, 2fr);
 		min-height: 720px;
 		min-width: 1280px;
-		padding: 8px;
+		padding: var(--base-spacing);
 		width: 100%;
 		height: calc(100vh - var(--header-size));
 
@@ -36,7 +36,7 @@ nz-layout {
 			height: 100%;
 			width: 100%;
 			background-color: snow;
-			padding: 16px;
+			padding: calc(2 * var(--base-spacing));
 			border-radius: 2px;
 		}
 


### PR DESCRIPTION
# Description

This PR adds a global css parameter for spacing. The spacing is set to `8px` as reasoned [here](https://t-i-show.medium.com/why-are-there-so-many-multiples-of-8-in-web-ui-design-f6bb78a49625#:~:text=Benefits%20of%20making%20margin%20a%20multiple%20of%208&text=This%20is%20the%20main%20standard,8%2C%20it%20would%20fit%20neatly.) and [here](https://stackoverflow.com/questions/69249431/why-mostly-values-are-multiples-of-8-in-android-xml).

Furthermore, this refactors the design of the dev login component.

# Checklist:

- [x] The title of this PR and the commit history is conform with
	the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings, SonarCloud reports no Vulnerabilities, Bugs or Code Smells.
- [x] I have added tests (unit and E2E if user-facing) that prove my fix is effective or that my feature works,
	Coverage > 80% and not less than the current coverage of the main branch.
- [x] The PR branch is up-to-date with the base branch. In case you merged `main` into your feature branch, make sure you have run the latest NX migrations (`nx migrate --run-migrations`).
