### PR TITLE
fix: creating sse connection for each gql subscribe

### DIFF
--- a/apps/api/src/app/controllers/graphql-subscriptions.controller.ts
+++ b/apps/api/src/app/controllers/graphql-subscriptions.controller.ts
@@ -1,7 +1,7 @@
 import {
+	All,
 	Controller,
 	OnModuleInit,
-	Post,
 	Req,
 	Res,
 	ServiceUnavailableException,
@@ -28,7 +28,7 @@ export class GraphqlSubscriptionsController implements OnModuleInit {
 		});
 	}
 
-	@Post()
+	@All()
 	subscriptionHandler(
 		@Req() req: KordisRequest,
 		@Res() res: Response,

--- a/libs/spa/core/graphql/src/lib/graphql.module.ts
+++ b/libs/spa/core/graphql/src/lib/graphql.module.ts
@@ -39,6 +39,7 @@ export class GraphqlModule {
 							},
 							new SSELink({
 								url: sseEndpoint,
+								singleConnection: true,
 								headers: () => ({
 									...authHeaderFactory(),
 								}),

--- a/libs/spa/core/graphql/src/lib/sse-link.ts
+++ b/libs/spa/core/graphql/src/lib/sse-link.ts
@@ -8,9 +8,9 @@ import { print } from 'graphql';
 import { Client, ClientOptions, createClient } from 'graphql-sse';
 
 export class SSELink extends ApolloLink {
-	private client: Client;
+	private client: Client<true>;
 
-	constructor(options: ClientOptions) {
+	constructor(options: ClientOptions<true>) {
 		super();
 		this.client = createClient(options);
 	}


### PR DESCRIPTION
As Browsers limit the amount of open SSE connections,  we have to use the `singleConnection` of the graphql-sse package. This only creates one connection for all subscriptions instead of one for each subscription.